### PR TITLE
Fix SoC name handling in LAVA v2 callback data

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -47,6 +47,7 @@ META_DATA_MAP = {
     models.JOB_KEY: "kernel.tree",
     models.ARCHITECTURE_KEY: "job.arch",
     models.DTB_KEY: "platform.dtb",
+    models.MACH_KEY: "platform.mach",
     models.FASTBOOT_KEY: "platform.fastboot",
     models.INITRD_KEY: "job.initrd_url",
     models.BOARD_KEY: "device.type",
@@ -73,7 +74,6 @@ def _get_definition_meta(meta, job_data):
     """
     meta["board_instance"] = job_data["actual_device_id"]
     definition = yaml.load(job_data["definition"], Loader=yaml.CLoader)
-    meta["mach"] = definition["device_type"]
     job_meta = definition["metadata"]
     meta.update({x: job_meta[y] for x, y in META_DATA_MAP.iteritems()})
 


### PR DESCRIPTION
The SoC name is now passed in the LAVA v2 job definition as
'platform.mach' so read it from the callback data to populate the
'mach' meta-data for each boot.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>