### PR TITLE
Update the test POST API

### DIFF
--- a/app/handlers/test_set.py
+++ b/app/handlers/test_set.py
@@ -75,6 +75,10 @@ class TestSetHandler(htbase.TestBaseHandler):
                         response.headers = {
                             "Location": "/test/set/%s" % str(doc_id)}
 
+                        # Update test_suite add test set ID
+                        self._update_test_suite_add_test_set_id(
+                            doc_id, suite_oid, suite_name)
+
                         if test_cases:
                             if isinstance(test_cases, types.ListType):
                                 response.status_code = 202
@@ -105,6 +109,25 @@ class TestSetHandler(htbase.TestBaseHandler):
 
         return response
 
+    def _update_test_suite_add_test_set_id(self, set_oid, suite_oid, suite_name):
+        """Execute the async task to add the test set ID onto the test suite.
+
+        :param set_oid: The ID of the test set.
+        :type set_oid: bson.objectid.ObjectId
+        :param suite_oid: The ID of the test suite.
+        :type suite_oid: bson.objectid.ObjectId
+        :param suite_name: The name of the test suite.
+        :type suite_name: str
+        """
+        taskq.update_test_suite_add_test_set_id.apply_async(
+            [
+                set_oid,
+                suite_oid,
+                suite_name,
+                self.settings["dboptions"], self.settings["mailoptions"]
+            ]
+        )
+
     def _import_test_cases(self, test_cases, set_oid, suite_oid, suite_name):
         """Execute the async task to import the test cases.
 
@@ -114,6 +137,8 @@ class TestSetHandler(htbase.TestBaseHandler):
         :type set_oid: bson.objectid.ObjectId
         :param suite_oid: The ID of the test suite.
         :type suite_oid: bson.objectid.ObjectId
+        :param suite_name: The name of the test suite.
+        :type suite_name: str
         """
         taskq.import_test_cases_from_test_set.apply_async(
             [

--- a/app/handlers/test_set.py
+++ b/app/handlers/test_set.py
@@ -109,7 +109,8 @@ class TestSetHandler(htbase.TestBaseHandler):
 
         return response
 
-    def _update_test_suite_add_test_set_id(self, set_oid, suite_oid, suite_name):
+    def _update_test_suite_add_test_set_id(
+            self, set_oid, suite_oid, suite_name):
         """Execute the async task to add the test set ID onto the test suite.
 
         :param set_oid: The ID of the test set.
@@ -124,7 +125,6 @@ class TestSetHandler(htbase.TestBaseHandler):
                 set_oid,
                 suite_oid,
                 suite_name,
-                self.settings["dboptions"], self.settings["mailoptions"]
             ]
         )
 

--- a/app/taskqueue/tasks/test.py
+++ b/app/taskqueue/tasks/test.py
@@ -208,10 +208,13 @@ def import_test_cases_from_test_set(
     # TODO: handle errors.
     return ret_val
 
+
 @taskc.app.task(
-    name="update-test-suite-add-test-set-id", ignore_result=False, add_to_parent=False)
+    name="update-test-suite-add-test-set-id",
+    ignore_result=False,
+    add_to_parent=False)
 def update_test_suite_add_test_set_id(
-        set_id, suite_id, suite_name, db_options, mail_options):
+        set_id, suite_id, suite_name):
     """Wrapper around the real import function."""
 
     """Add the test set ID into a test suite.
@@ -225,15 +228,12 @@ def update_test_suite_add_test_set_id(
     :type suite_id: bson.objectid.ObjectId
     :param suite_name: The name of the test suite.
     :type suite_name: str
-    :param db_options: The database connection parameters.
-    :type db_options: dict
-    :param mail_options: The email system parameters.
-    :type mail_options: dict
     :return 200 if OK, 500 in case of errors; a dictionary with errors or an
     empty one.
     """
 
     ret_val, errors = tests_import.update_test_suite_add_test_set_id(
-        set_id, suite_id, suite_name, db_options, mail_options)
+        set_id, suite_id, suite_name,
+        taskc.app.conf.db_options, taskc.app.conf.mail_options)
     # TODO: handle errors.
     return ret_val

--- a/app/taskqueue/tasks/test.py
+++ b/app/taskqueue/tasks/test.py
@@ -207,3 +207,33 @@ def import_test_cases_from_test_set(
         set_id, suite_id, suite_name, tests_list, db_options)
     # TODO: handle errors.
     return ret_val
+
+@taskc.app.task(
+    name="update-test-suite-add-test-set-id", ignore_result=False, add_to_parent=False)
+def update_test_suite_add_test_set_id(
+        set_id, suite_id, suite_name, db_options, mail_options):
+    """Wrapper around the real import function."""
+
+    """Add the test set ID into a test suite.
+
+    This task is linked from the test set post one: It add the
+    test set ID as a child of the test suite.
+
+    :param set_id: The ID of the test set.
+    :type set_id: bson.objectid.ObjectId
+    :param suite_id: The ID of the suite.
+    :type suite_id: bson.objectid.ObjectId
+    :param suite_name: The name of the test suite.
+    :type suite_name: str
+    :param db_options: The database connection parameters.
+    :type db_options: dict
+    :param mail_options: The email system parameters.
+    :type mail_options: dict
+    :return 200 if OK, 500 in case of errors; a dictionary with errors or an
+    empty one.
+    """
+
+    ret_val, errors = tests_import.update_test_suite_add_test_set_id(
+        set_id, suite_id, suite_name, db_options, mail_options)
+    # TODO: handle errors.
+    return ret_val

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -121,7 +121,7 @@ def find_one(collection, value, field="_id", operator="$in", fields=None):
         `_id`.
     :param oeprator: The operator used to perform the comparison. Defaults to
         `$in`.
-    :param fields: The fiels that should be available or excluded from the
+    :param fields: The fields that should be available or excluded from the
         result.
     :return None or the search result as a dictionary.
     """
@@ -151,7 +151,7 @@ def find_one2(collection, spec_or_id, fields=None):
 
     :param collection: The collection where to search.
     :param spec_or_id: A `spec` data structure or the document id.
-    :param fields: The fiels that should be available or excluded from the
+    :param fields: The fields that should be available or excluded from the
     result.
     :return None or the search result as a dictionary.
     """
@@ -168,7 +168,7 @@ def find_one3(
     :param collection: The collection where to search.
     :type collection: str
     :param spec_or_id: A `spec` data structure or the document id.
-    :param fields: The fiels that should be available or excluded from the
+    :param fields: The fields that should be available or excluded from the
     result.
     :param sort: The sort data structure.
     :param db_options: The connection parameters.

--- a/app/utils/tests_import.py
+++ b/app/utils/tests_import.py
@@ -449,6 +449,7 @@ def import_test_case(
     if isinstance(json_obj, types.DictionaryType):
         j_get = json_obj.get
         json_suite_id = j_get(models.TEST_SUITE_ID_KEY, None)
+        suite_oid = bson.objectid.ObjectId(suite_id)
 
         json_obj[models.TEST_SUITE_NAME_KEY] = suite_name
         if not json_suite_id:
@@ -456,24 +457,25 @@ def import_test_case(
             json_obj[models.TEST_SUITE_ID_KEY] = suite_id
         else:
             if json_suite_id == str(suite_id):
-                json_obj[models.TEST_SUITE_ID_KEY] = suite_id
+                json_obj[models.TEST_SUITE_ID_KEY] = suite_oid
             else:
                 utils.LOG.warning(
                     "Test suite ID does not match the provided one")
                 # XXX For now, force the suite_id value.
-                json_obj[models.TEST_SUITE_ID_KEY] = suite_id
+                json_obj[models.TEST_SUITE_ID_KEY] = suite_oid
 
         try:
             test_name = j_get(models.NAME_KEY, None)
+            set_id = j_get(models.TEST_SET_ID_KEY, None)
+            if set_id:
+                json_obj[models.TEST_SET_ID_KEY] = bson.objectid.ObjectId(set_id)
+            else:
+                json_obj[models.TEST_SET_ID_KEY] = None
             test_case = mtcase.TestCaseDocument.from_json(json_obj)
 
             if test_case:
-                k_get = kwargs.get
-
                 test_case.created_on = datetime.datetime.now(
                     tz=bson.tz_util.utc)
-                test_case.test_set_id = k_get(models.TEST_SET_ID_KEY, None)
-
                 ret_val, doc_id = utils.db.save(
                     database, test_case, manipulate=True)
 
@@ -481,6 +483,15 @@ def import_test_case(
                     err_msg = "Error saving test case '%s'" % test_name
                     utils.LOG.error(err_msg)
                     ADD_ERR(errors, 500, err_msg)
+                # If test case imported correctly reference it in the test suite
+                else:
+                    update_test_suite_add_test_case_id(
+                        doc_id, suite_oid, suite_name,
+                        db_options)
+                    #and in the test set if it exists
+                    if set_id:
+                        update_test_set_add_test_case_id(
+                            doc_id, bson.objectid.ObjectId(set_id), db_options)
             else:
                 ADD_ERR(errors, 400, "Missing mandatory key in JSON data")
         except ValueError, ex:
@@ -573,6 +584,7 @@ def import_test_cases_from_test_set(
 
     return ret_val, errors
 
+# TODO: create a separate test_update.py document
 
 def update_test_suite_add_test_set_id(
         set_id, suite_id, suite_name, db_options, mail_options):
@@ -613,5 +625,83 @@ def update_test_suite_add_test_set_id(
             ret_val,
             "Error updating test suite '%s' with test set references" %
             (str(suite_id))
+        )
+    return ret_val,errors
+
+def update_test_suite_add_test_case_id(
+        case_id, suite_id, suite_name, db_options):
+    """Add the test set ID provided in a test suite.
+
+    This task is linked from the test set post one: It add the
+    test set ID as a child of the test suite.
+
+    :param case_id: The ID of the test set.
+    :type case_id: bson.objectid.ObjectId
+    :param suite_id: The ID of the suite.
+    :type suite_id: bson.objectid.ObjectId
+    :param suite_name: The name of the test suite.
+    :type suite_name: str
+    :param db_options: The database connection parameters.
+    :type db_options: dict
+    :return 200 if OK, 500 in case of errors; a dictionary with errors or an
+    empty one.
+    """
+
+    ret_val = 200
+    errors = {}
+
+    utils.LOG.info(
+        "Updating test suite '%s' (%s) with test case ID",
+        suite_name, str(suite_id))
+    database = utils.db.get_db_connection(db_options)
+
+    ret_val = utils.db.update(
+        database[models.TEST_SUITE_COLLECTION],
+        {models.ID_KEY: suite_id},
+        {models.TEST_CASE_KEY: case_id}, operation='$push')
+    if ret_val != 200:
+        ADD_ERR(
+            errors,
+            ret_val,
+            "Error updating test suite '%s' with test case references" %
+            (str(suite_id))
+        )
+    return ret_val,errors
+
+def update_test_set_add_test_case_id(
+        case_id, set_id, db_options):
+    """Add the test set ID provided in a test set.
+
+    This task is linked from the test set post one: It add the
+    test set ID as a child of the test set.
+
+    :param case_id: The ID of the test set.
+    :type case_id: bson.objectid.ObjectId
+    :param set_id: The ID of the set.
+    :type set_id: bson.objectid.ObjectId
+    :param db_options: The database connection parameters.
+    :type db_options: dict
+    :return 200 if OK, 500 in case of errors; a dictionary with errors or an
+    empty one.
+    """
+
+    ret_val = 200
+    errors = {}
+
+    utils.LOG.info(
+        "Updating test set (%s) with test case ID",
+        str(set_id))
+    database = utils.db.get_db_connection(db_options)
+
+    ret_val = utils.db.update(
+        database[models.TEST_SET_COLLECTION],
+        {models.ID_KEY: set_id},
+        {models.TEST_CASE_KEY: case_id}, operation='$push')
+    if ret_val != 200:
+        ADD_ERR(
+            errors,
+            ret_val,
+            "Error updating test set '%s' with test case references" %
+            (str(set_id))
         )
     return ret_val,errors

--- a/app/utils/tests_import.py
+++ b/app/utils/tests_import.py
@@ -56,6 +56,7 @@ def _get_document_and_update(oid, collection, fields, up_doc, validate_func):
             }
         )
 
+
 def parse_test_suite(suite_json, db_options):
     """Parse the test suite JSON and retrieve the values to update.
 
@@ -468,9 +469,11 @@ def import_test_case(
             test_name = j_get(models.NAME_KEY, None)
             set_id = j_get(models.TEST_SET_ID_KEY, None)
             if set_id:
-                json_obj[models.TEST_SET_ID_KEY] = bson.objectid.ObjectId(set_id)
+                set_id = bson.objectid.ObjectId(set_id)
+                json_obj[models.TEST_SET_ID_KEY] = set_id
             else:
                 json_obj[models.TEST_SET_ID_KEY] = None
+
             test_case = mtcase.TestCaseDocument.from_json(json_obj)
 
             if test_case:
@@ -483,15 +486,16 @@ def import_test_case(
                     err_msg = "Error saving test case '%s'" % test_name
                     utils.LOG.error(err_msg)
                     ADD_ERR(errors, 500, err_msg)
-                # If test case imported correctly reference it in the test suite
+                # If test case imported correctly
+                # reference it in the test suite
                 else:
                     update_test_suite_add_test_case_id(
                         doc_id, suite_oid, suite_name,
                         db_options)
-                    #and in the test set if it exists
+                    # and in the test set if it exists
                     if set_id:
                         update_test_set_add_test_case_id(
-                            doc_id, bson.objectid.ObjectId(set_id), db_options)
+                            doc_id, set_id, db_options)
             else:
                 ADD_ERR(errors, 400, "Missing mandatory key in JSON data")
         except ValueError, ex:
@@ -586,6 +590,7 @@ def import_test_cases_from_test_set(
 
 # TODO: create a separate test_update.py document
 
+
 def update_test_suite_add_test_set_id(
         set_id, suite_id, suite_name, db_options, mail_options):
     """Add the test set ID provided in a test suite.
@@ -626,7 +631,8 @@ def update_test_suite_add_test_set_id(
             "Error updating test suite '%s' with test set references" %
             (str(suite_id))
         )
-    return ret_val,errors
+    return ret_val, errors
+
 
 def update_test_suite_add_test_case_id(
         case_id, suite_id, suite_name, db_options):
@@ -666,7 +672,8 @@ def update_test_suite_add_test_case_id(
             "Error updating test suite '%s' with test case references" %
             (str(suite_id))
         )
-    return ret_val,errors
+    return ret_val, errors
+
 
 def update_test_set_add_test_case_id(
         case_id, set_id, db_options):
@@ -704,4 +711,4 @@ def update_test_set_add_test_case_id(
             "Error updating test set '%s' with test case references" %
             (str(set_id))
         )
-    return ret_val,errors
+    return ret_val, errors

--- a/app/utils/tests_import.py
+++ b/app/utils/tests_import.py
@@ -56,7 +56,6 @@ def _get_document_and_update(oid, collection, fields, up_doc, validate_func):
             }
         )
 
-
 def parse_test_suite(suite_json, db_options):
     """Parse the test suite JSON and retrieve the values to update.
 
@@ -573,3 +572,46 @@ def import_test_cases_from_test_set(
         ADD_ERR(errors, ret_val, error_msg)
 
     return ret_val, errors
+
+
+def update_test_suite_add_test_set_id(
+        set_id, suite_id, suite_name, db_options, mail_options):
+    """Add the test set ID provided in a test suite.
+
+    This task is linked from the test set post one: It add the
+    test set ID as a child of the test suite.
+
+    :param set_id: The ID of the test set.
+    :type set_id: bson.objectid.ObjectId
+    :param suite_id: The ID of the suite.
+    :type suite_id: bson.objectid.ObjectId
+    :param suite_name: The name of the test suite.
+    :type suite_name: str
+    :param db_options: The database connection parameters.
+    :type db_options: dict
+    :param mail_options: The email system parameters.
+    :type mail_options: dict
+    :return 200 if OK, 500 in case of errors; a dictionary with errors or an
+    empty one.
+    """
+
+    ret_val = 200
+    errors = {}
+
+    utils.LOG.info(
+        "Updating test suite '%s' (%s) with test set ID",
+        suite_name, str(suite_id))
+    database = utils.db.get_db_connection(db_options)
+
+    ret_val = utils.db.update(
+        database[models.TEST_SUITE_COLLECTION],
+        {models.ID_KEY: suite_id},
+        {models.TEST_SET_KEY: set_id}, operation='$push')
+    if ret_val != 200:
+        ADD_ERR(
+            errors,
+            ret_val,
+            "Error updating test suite '%s' with test set references" %
+            (str(suite_id))
+        )
+    return ret_val,errors


### PR DESCRIPTION
Update the test_set POST API to:
- add the created test_set as a child of test_suite

Update the test_case POST API to:
- keep test_set and test_suite references in the test_case object
- add the created test_case as a child of test_suite and test_set

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>