### PR TITLE
split requirements.txt in two

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,6 +27,8 @@ installed as well. Skip them with:
 
 Non exhaustive list of requirements is in the 'requirements.txt' file: those
 need to be installed via pip.
+For production, requirements.txt is sufficient. For development purpose, requirements-dev.txt
+will add extra package for testing.
 
 For the rest of the necessary packages, see the ansible playbook.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+mock>0.7.2
+mongomock==1.2.0
+fakeredis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
 Sphinx==1.4.9
 celery[redis]==3.1.25
 docutils==0.12
-fakeredis
 futures==3.0.4
 hiredis
 jinja2
-mock>0.7.2
-mongomock==1.2.0
 netaddr==0.7.18
 pycares==1.0.0
 pymongo==2.8.1


### PR DESCRIPTION
This patch splits requirements.txt in two:
- requirements.txt for common requirements between production and dev
- requirements-dev.txt for requirements needed only by dev

Signed-off-by: Corentin LABBE <clabbe@baylibre.com>