### PR TITLE
New lava v2 callback for lava tests

### DIFF
--- a/app/models/test_case.py
+++ b/app/models/test_case.py
@@ -29,7 +29,7 @@ class TestCaseDocument(mbase.BaseDocument):
     is run and that reports a result.
     """
 
-    def __init__(self, name, test_suite_id, version="1.0"):
+    def __init__(self, name, status="PASS", test_suite_id=None, version="1.0"):
         """
 
         :param name: The name given to this test case.
@@ -43,14 +43,13 @@ class TestCaseDocument(mbase.BaseDocument):
         self._created_on = None
         self._id = None
         self._name = name
-        self._version = version
-
+        self._status = status
         self._test_suite_id = test_suite_id
+        self._version = version
 
         self._attachments = []
         self._measurements = []
         self._parameters = {}
-        self._status = "PASS"
 
         self.definition_uri = None
         self.kvm_guest = None

--- a/app/models/test_case.py
+++ b/app/models/test_case.py
@@ -29,7 +29,7 @@ class TestCaseDocument(mbase.BaseDocument):
     is run and that reports a result.
     """
 
-    def __init__(self, name, status="PASS", test_suite_id=None, version="1.0"):
+    def __init__(self, name, test_suite_id=None, version="1.0", status="PASS"):
         """
 
         :param name: The name given to this test case.

--- a/app/models/test_suite.py
+++ b/app/models/test_suite.py
@@ -17,18 +17,18 @@ import copy
 import types
 
 import models
-import models.base as mbase
+import models.base as modb
 
 
 # pylint: disable=invalid-name
 # pylint: disable=too-many-instance-attributes
-class TestSuiteDocument(mbase.BaseDocument):
+class TestSuiteDocument(modb.BaseDocument):
     """Model for a test suite document.
 
     A test suite is a document that can store test cases and/or test sets ran.
     """
 
-    def __init__(self, name, lab_name, build_id, version="1.0"):
+    def __init__(self, name, lab_name, build_id=None, version="1.0"):
         """The test suite document.
 
         :param name: The name given to this test suite.

--- a/app/taskqueue/tasks/callback.py
+++ b/app/taskqueue/tasks/callback.py
@@ -51,8 +51,11 @@ def lava_test(json_obj, lab_name):
     :type lab_name: string
     :return tuple The return code and the test document id.
     """
+    ret_code, boot_doc_id, errors = \
+        utils.callback.lava.add_boot(json_obj, lab_name,
+                                     taskc.app.conf.db_options)
     ret_code, doc_id, errors = \
-        utils.callback.lava.add_tests(json_obj, lab_name,
+        utils.callback.lava.add_tests(json_obj, lab_name, boot_doc_id,
                                       taskc.app.conf.db_options)
     # TODO: handle errors.
     return ret_code, doc_id

--- a/app/taskqueue/tasks/callback.py
+++ b/app/taskqueue/tasks/callback.py
@@ -36,3 +36,23 @@ def lava_boot(json_obj, lab_name):
                                      taskc.app.conf.db_options)
     # TODO: handle errors.
     return ret_code, doc_id
+
+
+@taskc.app.task(name="lava-test")
+def lava_test(json_obj, lab_name):
+    """Add test data from a LAVA v2 job callback
+
+    This is a wrapper around the actual function which runs in a Celery task.
+
+    :param json_obj: The JSON object with the values necessary to import the
+    LAVA test data.
+    :type json_obj: dictionary
+    :param lab_name: The name of the LAVA lab that posted the callback.
+    :type lab_name: string
+    :return tuple The return code and the test document id.
+    """
+    ret_code, doc_id, errors = \
+        utils.callback.lava.add_tests(json_obj, lab_name,
+                                      taskc.app.conf.db_options)
+    # TODO: handle errors.
+    return ret_code, doc_id

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -321,7 +321,8 @@ def add_boot(job_data, lab_name, db_options, base_path=utils.BASE_PATH):
     return ret_code, doc_id, errors
 
 
-def add_tests(job_data, lab_name, db_options, base_path=utils.BASE_PATH):
+def add_tests(job_data, lab_name, boot_doc_id,
+              db_options, base_path=utils.BASE_PATH):
     """Entry point to be used as an external task.
 
     This function should only be called by Celery or other task managers.
@@ -332,6 +333,8 @@ def add_tests(job_data, lab_name, db_options, base_path=utils.BASE_PATH):
     :type job_data: dict
     :param lab_name: Name of the LAVA lab that posted the callback.
     :type lab_name: string
+    :param boot_doc_id: The ID of the boot document related to this test suite
+    :type boot_doc_id: str
     :param db_options: The mongodb database connection parameters.
     :type db_options: dict
     :param base_path: Path to the top-level directory where to save files.
@@ -345,6 +348,7 @@ def add_tests(job_data, lab_name, db_options, base_path=utils.BASE_PATH):
     meta = {
         "version": "1.0",
         "lab_name": lab_name,
+        "boot_id": boot_doc_id,
         "time": "0.0",
     }
     # List of test cases data

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -15,19 +15,12 @@ import errno
 import models
 import os
 import yaml
-from decimal import Decimal
 
 import utils
-import utils.tests_import as tests_import
 import utils.boot
 import utils.kci_test
 import utils.db
 import utils.lava_log_parser
-import pymongo
-import models.test_suite as mtest_suite
-import models.test_case as mtest_case
-import datetime
-import bson
 
 # copied from lava-server/lava_scheduler_app/models.py
 SUBMITTED = 0
@@ -45,7 +38,6 @@ LAVA_JOB_RESULT = {
 DATA_MAP_TEST_CASE = {
     models.NAME_KEY: "name",
     models.STATUS_KEY: "result",
-
 }
 
 META_DATA_MAP_TEST_SUITE = {

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -94,6 +94,7 @@ def _get_test_case_data(meta, tc_data, job_data, META_DATA_MAP):
     :type META_DATA_MAP: list
     """
     test_key = None
+    found = None
     common_meta = {
         "version": "1.0",
         # Time shoud be passed in the result as well
@@ -101,16 +102,21 @@ def _get_test_case_data(meta, tc_data, job_data, META_DATA_MAP):
     }
     # TODO: Fix ?
     # Kind of workaround because the key for a test will be <number>_test_name
-    # Always using first found key for now
+    # Searching for the test plan.
+    # But, if the test plan name != test_suite name use the first test suite
+    # reported.
     for key in job_data["results"]:
+        if "0_" in key:
+            test_key = key
         if meta[models.NAME_KEY] in key:
             test_key = key
+            found = True
             break
 
-    if test_key is None:
-        utils.LOG.error("Could not find test data for '%s' in lava callback",
-                        meta[models.NAME_KEY])
-        return
+    if not found:
+        utils.LOG.warn("Could not find test data for '%s' in lava callback,"
+                       " using the first test report available: %s" %
+                       (meta[models.NAME_KEY], test_key))
 
     tests = yaml.load(job_data["results"][test_key],
                       Loader=yaml.CLoader)

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -1,0 +1,577 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Container for all the kci_test import related functions."""
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+import bson
+import copy
+import datetime
+import errno
+import io
+import os
+import pymongo
+import re
+
+import models
+import models.test_suite as mtest_suite
+import models.test_case as mtest_case
+import utils
+import utils.db
+import utils.errors
+import utils.tests_import as tests_import
+
+try:  # Py3K compat
+    basestring
+except NameError:
+    basestring = str
+
+# Some dtb appears to be in a temp directory like 'tmp', and will results in
+# some weird names.
+TMP_RE = re.compile(r"tmp")
+
+# Keys that need to be checked for None or null value.
+NON_NULL_KEYS_SUITE = [
+    models.BOARD_KEY,
+    models.DEFCONFIG_KEY,
+    models.JOB_KEY,
+    models.KERNEL_KEY
+]
+
+NON_NULL_KEYS_CASE = [
+    models.NAME_KEY,
+    models.STATUS_KEY,
+]
+
+# Local error function.
+ERR_ADD = utils.errors.add_error
+
+
+class TestImportError(Exception):
+    """General boot import exceptions class."""
+
+
+class TestValidationError(ValueError, TestImportError):
+    """General error for values of boot data."""
+
+
+def save_or_update(test_doc, database, errors):
+    """Save or update the document in the database.
+
+    Check if we have a document available in the db, and in case perform an
+    update on it.
+
+    :param test_doc: The test document to save.
+    :type test_doc: BaseDocument
+    :param database: The database connection.
+    :param errors: Where errors should be stored.
+    :type errors: dict
+    :return The save action return code and the doc ID.
+    """
+    spec = {
+        models.ARCHITECTURE_KEY: test_doc.arch,
+        models.BOARD_KEY: test_doc.board,
+        models.DEFCONFIG_FULL_KEY: (
+            test_doc.defconfig_full or test_doc.defconfig),
+        models.DEFCONFIG_KEY: test_doc.defconfig,
+        models.JOB_KEY: test_doc.job,
+        models.KERNEL_KEY: test_doc.kernel,
+        models.LAB_NAME_KEY: test_doc.lab_name,
+        models.GIT_BRANCH_KEY: test_doc.git_branch
+    }
+
+    fields = [
+        models.CREATED_KEY,
+        models.ID_KEY,
+    ]
+
+    # Clear the BOOT keys
+    # look at the test_suite and test_case split
+
+    prev_doc = utils.db.find_one2(
+        database[models.TEST_SUITE_COLLECTION], spec, fields=fields)
+
+    if prev_doc:
+        doc_get = prev_doc.get
+        doc_id = doc_get(models.ID_KEY)
+        test_doc.id = doc_id
+        test_doc.created_on = doc_get(models.CREATED_KEY)
+
+        utils.LOG.info("Updating test_suite document with id '%s'", doc_id)
+        ret_val, _ = utils.db.save(database, test_doc)
+    else:
+        ret_val, doc_id = utils.db.save(database, test_doc, manipulate=True)
+
+    if ret_val == 500:
+        err_msg = (
+            "Error saving/updating test report in the database "
+            "for '%s-%s-%s-%s (%s, %s)'" %
+            (
+                test_doc.job,
+                test_doc.git_branch,
+                test_doc.kernel,
+                test_doc.defconfig_full, test_doc.arch, test_doc.board
+            )
+        )
+        ERR_ADD(errors, ret_val, err_msg)
+
+    return ret_val, doc_id
+
+
+def save_to_disk(test_doc, json_obj, base_path, errors):
+    """Save the provided test report to disk.
+
+    :param test_doc: The document parsed.
+    :type test_doc: models.test.TestDocument
+    :param json_obj: The JSON data to write.
+    :type json_obj: dictionary
+    :param base_path: The base path where to save the document.
+    :type base_path: str
+    :param errors: Where errors should be stored.
+    :type errors: dictionary
+    """
+    dir_path = os.path.join(
+        base_path,
+        test_doc.job,
+        test_doc.git_branch,
+        test_doc.kernel,
+        test_doc.arch,
+        test_doc.defconfig_full, test_doc.lab_name)
+    file_path = os.path.join(dir_path, "test-{}.json".format(test_doc.board))
+
+    try:
+        if not os.path.isdir(dir_path):
+            try:
+                os.makedirs(dir_path)
+            except OSError, ex:
+                if ex.errno != errno.EEXIST:
+                    raise ex
+
+        with io.open(file_path, mode="w") as write_json:
+            write_json.write(
+                unicode(
+                    json.dumps(
+                        json_obj, indent="  ", default=bson.json_util.default),
+                    encoding="utf-8"
+                )
+            )
+    except (OSError, IOError), ex:
+        err_msg = "Error saving test report to '{}'".format(file_path)
+        utils.LOG.exception(ex)
+        utils.LOG.error(err_msg)
+        ERR_ADD(errors, 500, err_msg)
+
+
+def _check_for_null(test_dict, NON_NULL_KEYS):
+    """Check if the board dictionary has values resembling None in its
+    mandatory keys.
+
+    Values must be different than:
+    - None
+    - ""
+    - "null"
+
+    :param test_dict: The board dictoinary.
+    :type test_dict: dict
+    :param NON_NULL_KEYS: The dict of keys to parse and check for non null.
+    :type NON_NULL_KEYS: dict
+    :raise TestValidationError if any of the keys matches the condition.
+    """
+    for key in NON_NULL_KEYS:
+        val = test_dict.get(key, None)
+        if (val is None or
+            (isinstance(val, basestring) and
+                val.lower() in ('', 'null', 'none'))):
+            raise TestValidationError(
+                "Invalid value found for mandatory key {!r}: {!r}".format(
+                    key, val))
+
+
+def _get_test_seconds(test_dict):
+    """Returns test time in seconds"""
+    try:
+        test_time_raw = test_dict[models.TIME_KEY]
+    except KeyError:
+        raise TestValidationError("Test time missing")
+    try:
+        test_time = float(test_time_raw)
+    except ValueError:
+        raise TestValidationError(
+            "Test time is not a number: {!r}".format(test_time_raw))
+    if test_time < 0.0:
+        raise TestValidationError("Found negative test time")
+    return test_time
+
+
+def _seconds_as_datetime(seconds):
+    """
+    Returns seconds encoded as a point in time `seconds` seconds after since
+    1970-01-01T00:00:00Z.
+    """
+    return datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=seconds)
+
+
+def _update_test_case_doc_from_json(case_doc, test_dict, errors):
+    """Update a TestCaseDocument from the provided test dictionary.
+
+    This function does not return anything, and the TestCaseDocument passed is
+    updated from the values found in the provided JSON object.
+
+    :param case_doc: The TestCaseDocument to update.
+    :type case_doc: `models.test_case.TestCaseDocument`.
+    :param test_case: Test case dictionary.
+    :type test_case: dict
+    :param errors: Where errors should be stored.
+    :type errors: dict
+    """
+
+    try:
+        seconds = _get_test_seconds(test_dict)
+    except TestValidationError as ex:
+        seconds = 0.0
+        err_msg = "Error reading test time data; defaulting to 0"
+        utils.LOG.exception(ex)
+        utils.LOG.error(err_msg)
+        ERR_ADD(errors, 400, err_msg)
+
+    try:
+        case_doc.time = _seconds_as_datetime(seconds)
+    except OverflowError as ex:
+        seconds = 0.0
+        err_msg = "Test time value is too large for a time value, default to 0"
+        utils.LOG.exception(ex)
+        utils.LOG.error(err_msg)
+        ERR_ADD(errors, 400, err_msg)
+
+    if seconds == 0.0:
+        case_doc.time = _seconds_as_datetime(seconds)
+
+    case_doc.definition_uri = test_dict.get(models.DEFINITION_URI_KEY, None)
+    case_doc.kvm_guest = test_dict.get(models.KVM_GUEST_KEY, None)
+    case_doc.maximum = test_dict.get(models.MAXIMUM_KEY, None)
+    case_doc.metadata = test_dict.get(models.METADATA_KEY, None)
+    case_doc.minimum = test_dict.get(models.MINIMUM_KEY, None)
+    case_doc.samples = test_dict.get(models.SAMPLES_KEY, None)
+    case_doc.samples_sqr_sum = test_dict.get(models.SAMPLES_SQUARE_SUM_KEY,
+                                             None)
+    case_doc.samples_sum = test_dict.get(models.SAMPLES_SUM_KEY, None)
+    case_doc.vcs_commit = test_dict.get(models.VCS_COMMIT_KEY, None)
+    case_doc.version = test_dict.get(models.VERSION_KEY, "1.0")
+
+
+def _update_test_case_doc_ids(ts_name, ts_id, case_doc, database):
+    """Update test case document test suite IDs references.
+
+    :param ts_name: The test case name
+    :type ts_name: str
+    :param ts_id: The test case ID
+    :type ts_id: str
+    :param case_doc: The test case document to update.
+    :type case_doc: TestCaseDocument
+    :param database: The database connection to use.
+    """
+
+    # Make sure the test suite ID provided is correct
+    ts_oid = bson.objectid.ObjectId(ts_id)
+    test_suite_doc = utils.db.find_one2(database[models.TEST_SUITE_COLLECTION],
+                                        ts_oid,
+                                        [models.ID_KEY])
+    # If exists, update the test case
+    if test_suite_doc:
+        case_doc.test_suite_name = test_suite_doc.get(models.NAME_KEY, None)
+        case_doc.test_suite_id = test_suite_doc.get(models.ID_KEY, None)
+    else:
+        utils.LOG.error(
+            "No test suite document with ID %s found for test case %s",
+            ts_oid, case_doc.name)
+        return None
+
+
+def _parse_test_case_from_json(ts_name, ts_id, test_json, database, errors):
+    """Parse the test case report from a JSON object.
+
+    :param ts_name: The test case name
+    :type ts_name: str
+    :param ts_id: The test case ID
+    :type ts_id: str
+    :param test_json: The JSON object.
+    :type test_json: dict
+    :param database: The database connection.
+    :param errors: Where to store the errors.
+    :type errors: dict
+    :return A `models.test_case.TestCaseDocument` instance, or None if
+    the JSON cannot be parsed correctly.
+    """
+    if not test_json or not ts_name or not ts_id:
+        return None
+
+    try:
+        _check_for_null(test_json, NON_NULL_KEYS_CASE)
+    except TestValidationError, ex:
+        utils.LOG.exception(ex)
+        ERR_ADD(errors, 400, str(ex))
+        return None
+
+    try:
+        name = test_json[models.NAME_KEY]
+        status = test_json[models.STATUS_KEY].upper()
+    except KeyError, ex:
+        err_msg = "Missing mandatory key in test case data"
+        utils.LOG.exception(ex)
+        utils.LOG.error(err_msg)
+        ERR_ADD(errors, 400, err_msg)
+        return None
+
+    test_doc = mtest_case.TestCaseDocument(
+        name,
+        status)
+    test_doc.created_on = datetime.datetime.now(
+        tz=bson.tz_util.utc)
+    _update_test_case_doc_from_json(test_doc, test_json, errors)
+    _update_test_case_doc_ids(ts_name, ts_id, test_doc, database)
+    return test_doc
+
+
+def _update_test_suite_doc_from_json(suite_doc, test_dict, errors):
+    """Update a TestSuiteDocument from the provided test dictionary.
+
+    This function does not return anything, and the TestSuiteDocument passed is
+    updated from the values found in the provided JSON object.
+
+    :param suite_doc: The TestSuiteDocument to update.
+    :type suite_doc: `models.test_suite.TestSuiteDocument`.
+    :param test_suite: Test suite dictionary.
+    :type test_suite: dict
+    :param errors: Where errors should be stored.
+    :type errors: dict
+    """
+
+    try:
+        seconds = _get_test_seconds(test_dict)
+    except TestValidationError as ex:
+        seconds = 0.0
+        err_msg = "Error reading test time data; defaulting to 0"
+        utils.LOG.exception(ex)
+        utils.LOG.error(err_msg)
+        ERR_ADD(errors, 400, err_msg)
+
+    try:
+        suite_doc.time = _seconds_as_datetime(seconds)
+    except OverflowError as ex:
+        seconds = 0.0
+        err_msg = "Test time value is too large for a time value, default to 0"
+        utils.LOG.exception(ex)
+        utils.LOG.error(err_msg)
+        ERR_ADD(errors, 400, err_msg)
+
+    if seconds == 0.0:
+        suite_doc.time = _seconds_as_datetime(seconds)
+
+    suite_doc.board = test_dict.get(models.BOARD_KEY, None)
+    suite_doc.board_instance = test_dict.get(models.BOARD_INSTANCE_KEY, None)
+    suite_doc.vcs_commit = test_dict.get(models.VCS_COMMIT_KEY, None)
+    suite_doc.metadata = test_dict.get(models.METADATA_KEY, {})
+    suite_doc.version = test_dict.get(models.VERSION_KEY, "1.0")
+    suite_doc.git_branch = test_dict.get(models.GIT_BRANCH_KEY, None)
+    suite_doc.kernel = test_dict.get(models.KERNEL_KEY, None)
+    suite_doc.defconfig = test_dict.get(models.DEFCONFIG_KEY, None)
+    suite_doc.defconfig_full = test_dict.get(models.DEFCONFIG_FULL_KEY, None)
+    suite_doc.arch = test_dict.get(models.ARCHITECTURE_KEY, None)
+    suite_doc.job = test_dict.get(models.JOB_KEY, None)
+
+
+def _update_test_suite_doc_ids(suite_doc, database):
+    """Update test suite document job and build IDs references.
+
+    :param suite_doc: The test suite document to update.
+    :type suite_doc: TestSuiteDocument
+    :param database: The database connection to use.
+    """
+    job = suite_doc.job
+    kernel = suite_doc.kernel
+    defconfig = suite_doc.defconfig
+    defconfig_full = suite_doc.defconfig_full
+    arch = suite_doc.arch
+    branch = suite_doc.git_branch
+
+    spec = {
+        models.JOB_KEY: job,
+        models.KERNEL_KEY: kernel,
+        models.GIT_BRANCH_KEY: branch
+    }
+
+    job_doc = utils.db.find_one2(database[models.JOB_COLLECTION], spec)
+
+    spec.update({
+        models.ARCHITECTURE_KEY: arch,
+        models.DEFCONFIG_KEY: defconfig,
+        models.JOB_KEY: job,
+        models.KERNEL_KEY: kernel
+    })
+
+    if defconfig_full:
+        spec[models.DEFCONFIG_FULL_KEY] = defconfig_full
+
+    build_doc = utils.db.find_one2(database[models.BUILD_COLLECTION], spec)
+
+    if job_doc:
+        suite_doc.job_id = job_doc.get(models.ID_KEY, None)
+    else:
+        utils.LOG.warn(
+            "No job document found for test suite %s-%s-%s-%s (%s)",
+            job, branch, kernel, defconfig_full, arch)
+
+    if build_doc:
+        doc_get = build_doc.get
+        suite_doc.build_id = doc_get(models.ID_KEY, None)
+
+        # In case we do not have the job_id key with the previous search.
+        if all([not suite_doc.job_id, doc_get(models.JOB_ID_KEY, None)]):
+            suite_doc.job_id = doc_get(models.JOB_ID_KEY, None)
+        # Get also git information if we do not have them already,
+        if not suite_doc.git_branch:
+            suite_doc.git_branch = doc_get(models.GIT_BRANCH_KEY, None)
+        if not suite_doc.vcs_commit:
+            suite_doc.vcs_commit = doc_get(models.GIT_COMMIT_KEY, None)
+    else:
+        utils.LOG.warn(
+            "No build document found for test suite %s-%s-%s-%s (%s)",
+            job, branch, kernel, defconfig_full, arch)
+
+
+def _parse_test_suite_from_json(test_json, database, errors):
+    """Parse the test suite report from a JSON object.
+
+    :param test_json: The JSON object.
+    :type test_json: dict
+    :param database: The database connection.
+    :param errors: Where to store the errors.
+    :type errors: dict
+    :return A `models.test_suite.TestSuiteDocument` instance, or None if
+    the JSON cannot be parsed correctly.
+    """
+    if not test_json:
+        return None
+
+    try:
+        _check_for_null(test_json, NON_NULL_KEYS_SUITE)
+    except TestValidationError, ex:
+        utils.LOG.exception(ex)
+        ERR_ADD(errors, 400, str(ex))
+        return None
+
+    try:
+        name = test_json[models.NAME_KEY]
+        lab_name = test_json[models.LAB_NAME_KEY]
+    except KeyError, ex:
+        err_msg = "Missing mandatory key in test suite data"
+        utils.LOG.exception(ex)
+        utils.LOG.error(err_msg)
+        ERR_ADD(errors, 400, err_msg)
+        return None
+
+    arch = test_json.get(models.ARCHITECTURE_KEY, models.ARM_ARCHITECTURE_KEY)
+
+    if arch not in models.VALID_ARCHITECTURES:
+        err_msg = "Invalid architecture found: %s".format(arch)
+        utils.LOG.error(err_msg)
+        ERR_ADD(errors, 400, err_msg)
+        return None
+
+    test_doc = mtest_suite.TestSuiteDocument(
+        name,
+        lab_name)
+    test_doc.created_on = datetime.datetime.now(
+        tz=bson.tz_util.utc)
+    _update_test_suite_doc_from_json(test_doc, test_json, errors)
+    _update_test_suite_doc_ids(test_doc, database)
+    return test_doc
+
+
+def import_and_save_kci_test(test_suite_obj, test_case_obj,
+                             db_options, base_path=utils.BASE_PATH):
+    """Wrapper function to be used as an external task.
+
+    This function should only be called by Celery or other task managers.
+    Import and save the test report as found from the parameters in the
+    provided JSON object.
+
+    :param test_suite_obj: The JSON object with the values that identify
+    the test suite report log.
+    :type test_suite_obj: dict
+    :param test_case_obj: The JSON object with the values that identify
+    the test case report log.
+    :type test_case_obj: list
+    :param db_options: The mongodb database connection parameters.
+    :type db_options: dict
+    """
+    ret_code = None
+    ts_doc_id = None
+    tc_doc_id = None
+    errors = {}
+
+    try:
+        database = utils.db.get_db_connection(db_options)
+        ts_json_copy = copy.deepcopy(test_suite_obj)
+
+        ts_doc = _parse_test_suite_from_json(ts_json_copy, database, errors)
+        # If test suite imported correctly
+        if ts_doc and not errors:
+            # ret_code, ts_doc_id = save_or_update(ts_doc, database, errors)
+            # For now just save, do not update
+            ret_code, ts_doc_id = utils.db.save(database,
+                                                ts_doc, manipulate=True)
+            tc_json_copy = copy.deepcopy(test_case_obj)
+
+            for test_case in tc_json_copy:
+                tc_doc = \
+                    _parse_test_case_from_json(ts_doc.name, ts_doc_id,
+                                               test_case, database, errors)
+                if tc_doc:
+                    ret_code, tc_doc_id = utils.db.save(database, tc_doc,
+                                                        manipulate=True)
+
+                if ret_code == 500:
+                    err_msg = (
+                        "Error saving test case report in the database "
+                        "for '%s (%s, %s)'" %
+                        (
+                            tc_doc.name,
+                            tc_doc.status,
+                            tc_doc.test_suite_id,
+                        )
+                    )
+                    ERR_ADD(errors, ret_code, err_msg)
+                else:
+                    # Test case imported successfully update test suite
+                    ret_code, errors = \
+                        tests_import.update_test_suite_add_test_case_id(
+                            tc_doc_id, ts_doc_id, ts_doc.name, db_options)
+
+                if errors:
+                    utils.LOG.error("Error while importing test case")
+                    break
+            # TODO fix this: need to define a save_to_disk method
+            # save_to_disk(ts_doc, test_suite_obj, base_path, errors)
+        else:
+            utils.LOG.warn("No test suite report imported nor saved")
+    except pymongo.errors.ConnectionFailure, ex:
+        utils.LOG.exception(ex)
+        utils.LOG.error("Error getting database connection")
+        ERR_ADD(errors, 500, "Error connecting to the database")
+
+    return ret_code, ts_doc_id, errors

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -288,8 +288,8 @@ def _parse_test_case_from_json(ts_name, ts_id, test_json, database, errors):
         return None
 
     test_doc = mtest_case.TestCaseDocument(
-        name,
-        status)
+        name=name,
+        status=status)
     test_doc.created_on = datetime.datetime.now(
         tz=bson.tz_util.utc)
     _update_test_case_doc_from_json(test_doc, test_json, errors)
@@ -445,8 +445,8 @@ def _parse_test_suite_from_json(test_json, database, errors):
         return None
 
     test_doc = mtest_suite.TestSuiteDocument(
-        name,
-        lab_name)
+        name=name,
+        lab_name=lab_name)
     test_doc.created_on = datetime.datetime.now(
         tz=bson.tz_util.utc)
     _update_test_suite_doc_from_json(test_doc, test_json, errors)
@@ -493,8 +493,8 @@ def import_and_save_test_sets(test_cases, test_sets,
 
     for test_set_name in test_sets_set:
         test_set_doc = mtest_set.TestSetDocument(
-            test_set_name,
-            tsu_id)
+            name=test_set_name,
+            test_suite_id=tsu_id)
         test_set_doc.test_suite_name = tsu_name
         test_set_doc.created_on = datetime.datetime.now(
             tz=bson.tz_util.utc)

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -13,19 +13,10 @@
 
 """Container for all the kci_test import related functions."""
 
-try:
-    import simplejson as json
-except ImportError:
-    import json
-
 import bson
 import copy
 import datetime
-import errno
-import io
-import os
 import pymongo
-import re
 
 import models
 import models.test_suite as mtest_suite
@@ -623,7 +614,6 @@ def import_and_save_kci_test(test_suite_obj, test_case_obj,
     """
     ret_code = None
     ts_doc_id = None
-    tc_doc_id = None
     test_sets = {}
     errors = {}
 

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -162,6 +162,7 @@ def _update_test_case_doc_from_json(case_doc, test_dict, errors):
     case_doc.samples_sum = test_dict.get(models.SAMPLES_SUM_KEY, None)
     case_doc.vcs_commit = test_dict.get(models.VCS_COMMIT_KEY, None)
     case_doc.version = test_dict.get(models.VERSION_KEY, "1.0")
+    case_doc.measurements = test_dict.get(models.MEASUREMENTS_KEY, [])
 
 
 def _update_test_case_doc_ids(ts_name, ts_id, case_doc, database):

--- a/app/utils/kci_test/tests/__init__.py
+++ b/app/utils/kci_test/tests/__init__.py
@@ -1,0 +1,1 @@
+# TODO write python unit tests


### PR DESCRIPTION
On going work on lava tests callback. It parses the test definitions and creates -kernelci style- test database entries. 