### PR TITLE
Fix a typo in the URL of the installation documentation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Install
 
-All installation docs are now on the dedicated [kernelci-backend-config](https://github.com/kernelci/kernelci-backend/config/INSTALL.md)
+All installation docs are now on the dedicated [kernelci-backend-config](https://github.com/kernelci/kernelci-backend-config/INSTALL.md)
 
 # Configuration/Administration
 


### PR DESCRIPTION
Signed-off-by: Corentin LABBE <clabbe@baylibre.com>