### PR TITLE
Move email settings from Tornado to Celery config

### DIFF
--- a/app/handlers/compare.py
+++ b/app/handlers/compare.py
@@ -129,7 +129,6 @@ class CompareHandler(hbase.BaseHandler):
             [kwargs["json_obj"]],
             kwargs={
                 "db_options": self.settings["dboptions"],
-                "mail_options": self.settings["mailoptions"]
             }
         )
 

--- a/app/handlers/send.py
+++ b/app/handlers/send.py
@@ -113,7 +113,6 @@ class SendHandler(hbase.BaseHandler):
                     "in_reply_to": j_get(models.IN_REPLY_TO_KEY, None),
                     "subject": j_get(models.SUBJECT_KEY, None),
                     "db_options": self.settings["dboptions"],
-                    "mail_options": self.settings["mailoptions"],
                 }
 
                 email_type = []
@@ -261,8 +260,7 @@ class SendHandler(hbase.BaseHandler):
                     lab_name,
                     email_format,
                     to_addrs,
-                    s_get("db_options"),
-                    s_get("mail_options")
+                    s_get("db_options")
                 ],
                 kwargs={
                     "cc_addrs": cc_addrs,
@@ -318,8 +316,7 @@ class SendHandler(hbase.BaseHandler):
                     kernel,
                     email_format,
                     to_addrs,
-                    s_get("db_options"),
-                    s_get("mail_options")
+                    s_get("db_options")
                 ],
                 kwargs={
                     "cc_addrs": cc_addrs,

--- a/app/handlers/test_case.py
+++ b/app/handlers/test_case.py
@@ -54,13 +54,11 @@ class TestCaseHandler(htbase.TestBaseHandler):
                 self._check_and_get_test_suite(suite_id)
 
             if suite_oid:
-                other_args = {
-                    "mail_options": self.settings["mailoptions"]}
                 ret_val, doc_id, err_msg = tests_import.import_test_case(
                     test_case_json,
                     suite_oid,
                     suite_name,
-                    self.db, self.settings["dboptions"], **other_args
+                    self.db, self.settings["dboptions"]
                 )
                 response.status_code = ret_val
 

--- a/app/handlers/test_suite.py
+++ b/app/handlers/test_suite.py
@@ -131,8 +131,7 @@ class TestSuiteHandler(htbase.TestBaseHandler):
                                     suite_json,
                                     suite_id,
                                     suite_name,
-                                    self.settings["dboptions"],
-                                    self.settings["mailoptions"]
+                                    self.settings["dboptions"]
                                 ]
                             )
                     else:

--- a/app/server.py
+++ b/app/server.py
@@ -81,34 +81,15 @@ topt.define(
     "unixsocket",
     default=False, type=bool, help="If unix socket should be used")
 
-# Email options.
-topt.define(
-    "smtp_host", default="", type=str, help="The SMTP host to connect to")
-topt.define("smtp_user", default="", type=str, help="SMTP connection user")
-topt.define(
-    "smtp_password", default="", type=str, help="SMTP connection password")
-topt.define(
-    "smtp_port",
-    default=587, type=int, help="The SMTP connection port, default to 587")
-topt.define(
-    "smtp_sender", default="", type=str, help="The sender email address")
-topt.define(
-    "smtp_sender_desc",
-    default="",
-    type=str, help="The name/description of the sender email address"
-)
+# Email report delay in seconds
 topt.define(
     "send_delay",
     default=60 * 60 + 5,
     type=int,
     help="The delay in sending the emails, default to 1 hour and 5 seconds"
 )
-topt.define(
-    "info_email",
-    default=None,
-    type=str,
-    help="The email address to use for footnote in the email reports"
-)
+
+# Storage
 topt.define(
     "storage_url",
     default=None, type=str, help="The URL of the storage system")
@@ -141,16 +122,6 @@ class KernelCiBackend(tornado.web.Application):
             "redis_port": topt.options.redis_port
         }
 
-        mail_options = {
-            "smtp_host": topt.options.smtp_host,
-            "info_email": topt.options.info_email,
-            "smtp_password": topt.options.smtp_password,
-            "smtp_port": topt.options.smtp_port,
-            "smtp_sender": topt.options.smtp_sender,
-            "smtp_sender_desc": topt.options.smtp_sender_desc,
-            "smtp_user": topt.options.smtp_user
-        }
-
         if not self.database:
             self.database = utils.db.get_db_connection(db_options)
 
@@ -161,7 +132,6 @@ class KernelCiBackend(tornado.web.Application):
             "database": self.database,
             "redis_connection": self.redis_con,
             "dboptions": db_options,
-            "mailoptions": mail_options,
             "default_handler_class": happ.AppHandler,
             "executor": concurrent.futures.ThreadPoolExecutor(
                 topt.options.max_workers),

--- a/app/taskqueue/tasks/build.py
+++ b/app/taskqueue/tasks/build.py
@@ -51,8 +51,6 @@ def parse_single_build_log(prev_res):
     :type prev_res: list
     :param db_options: The database connection parameters.
     :type db_options: dictionary
-    :param mail_options: The options necessary to connect to the SMTP server.
-    :type mail_options: dictionary
     :return A 2-tuple: The status code, and the errors data structure.
     """
     status, errors = utils.log_parser.parse_single_build_log(

--- a/app/taskqueue/tasks/compare.py
+++ b/app/taskqueue/tasks/compare.py
@@ -21,7 +21,7 @@ import utils.compare.job
 
 
 @taskc.app.task(name="job-delta", ignore_result=False)
-def calculate_job_delta(json_obj, db_options=None, mail_options=None):
+def calculate_job_delta(json_obj, db_options=None):
     """Perform the job delta calculations.
 
     Wrapper around the real function to provide a task-based access.
@@ -30,15 +30,13 @@ def calculate_job_delta(json_obj, db_options=None, mail_options=None):
     :type json_obj: dict
     :param db_options: The database connection parameters.
     :type db_options: dict
-    :param mail_options: The email connection parameters.
-    :type mail_options: dict
     :return a 4-tuple: status code, result, doc_id, errors.
     """
     return utils.compare.job.execute_job_delta(json_obj, db_options)
 
 
 @taskc.app.task(name="build-delta", ignore_result=False)
-def calculate_build_delta(json_obj, db_options=None, mail_options=None):
+def calculate_build_delta(json_obj, db_options=None):
     """Perform the build delta calculations.
 
     Wrapper around the real function to provide a task-based access.
@@ -47,8 +45,6 @@ def calculate_build_delta(json_obj, db_options=None, mail_options=None):
     :type json_obj: dict
     :param db_options: The database connection parameters.
     :type db_options: dict
-    :param mail_options: The email connection parameters.
-    :type mail_options: dict
     :return A 4-tuple: status code, result, doc_id and errors.
     :rtype tuple
     """
@@ -56,7 +52,7 @@ def calculate_build_delta(json_obj, db_options=None, mail_options=None):
 
 
 @taskc.app.task(name="boot-delta", ignore_result=False)
-def calculate_boot_delta(json_obj, db_options=None, mail_options=None):
+def calculate_boot_delta(json_obj, db_options=None):
     """Perform the boot delta calculations.
 
     Wrapper around the real function to provide a task-based access.
@@ -65,8 +61,6 @@ def calculate_boot_delta(json_obj, db_options=None, mail_options=None):
     :type json_obj: dict
     :param db_options: The database connection parameters.
     :type db_options: dict
-    :param mail_options: The email connection parameters.
-    :type mail_options: dict
     :return A 4-tuple: status code, result, doc_id and errors.
     :rtype tuple
     """

--- a/app/taskqueue/tasks/report.py
+++ b/app/taskqueue/tasks/report.py
@@ -35,7 +35,6 @@ def send_boot_report(
         email_format,
         to_addrs,
         db_options,
-        mail_options,
         cc_addrs=None, bcc_addrs=None, in_reply_to=None, subject=None):
     """Create the boot report email and send it.
 
@@ -51,8 +50,6 @@ def send_boot_report(
     :type to_addrs: list
     :param db_options: The database connection parameters.
     :type db_options: dictionary
-    :param mail_options: The options necessary to connect to the SMTP server.
-    :type mail_options: dictionary
     :param cc: The list of addresses to add in CC.
     :type cc: list
     :param bcc: The list of addresses to add in BCC.
@@ -72,7 +69,8 @@ def send_boot_report(
             git_branch,
             kernel,
             lab_name,
-            email_format, db_options=db_options, mail_options=mail_options
+            email_format, db_options=db_options,
+            mail_options=taskc.app.conf.get("mail_options", None)
         )
 
     if not subject:
@@ -87,7 +85,7 @@ def send_boot_report(
             subject,
             txt_body,
             html_body,
-            mail_options,
+            taskc.app.conf.mail_options,
             headers=headers,
             cc_addrs=cc_addrs, bcc_addrs=bcc_addrs, in_reply_to=in_reply_to
         )
@@ -110,7 +108,6 @@ def send_build_report(
         email_format,
         to_addrs,
         db_options,
-        mail_options,
         cc_addrs=None, bcc_addrs=None, in_reply_to=None, subject=None):
     """Create the build report email and send it.
 
@@ -124,8 +121,6 @@ def send_build_report(
     :type to_addrs: list
     :param db_options: The database connection parameters.
     :type db_options: dictionary
-    :param mail_options: The options necessary to connect to the SMTP server.
-    :type mail_options: dictionary
     :param cc: The list of addresses to add in CC.
     :type cc: list
     :param bcc: The list of addresses to add in BCC.
@@ -146,7 +141,7 @@ def send_build_report(
             kernel,
             email_format,
             db_options=db_options,
-            mail_options=mail_options
+            mail_options=taskc.app.conf.get("mail_options", None)
         )
 
     if not subject:
@@ -159,7 +154,7 @@ def send_build_report(
             subject,
             txt_body,
             html_body,
-            mail_options,
+            taskc.app.conf.mail_options,
             headers=headers,
             cc_addrs=cc_addrs, bcc_addrs=bcc_addrs, in_reply_to=in_reply_to
         )
@@ -241,7 +236,7 @@ def send_multiple_emails_error(
             "Sending duplicate emails report for %s-%s-%s",
             job, git_branch, kernel)
         utils.emails.send_email(
-            [taskc.app.conf.mail_options.get("error_email")],
+            [taskc.app.conf.mail_options["error_email"]],
             subject,
             txt_body,
             html_body,

--- a/app/taskqueue/tasks/test.py
+++ b/app/taskqueue/tasks/test.py
@@ -28,7 +28,7 @@ ADD_ERR = utils.errors.add_error
 # pylint: disable=star-args
 @taskc.app.task(name="complete-test-suite-import", ignore_result=False)
 def complete_test_suite_import(
-        suite_json, suite_id, suite_name, db_options, mail_options):
+        suite_json, suite_id, suite_name, db_options):
     """Complete the test suite import.
 
     First update the test suite references, if what is provided is only the
@@ -42,8 +42,6 @@ def complete_test_suite_import(
     :type suite_name: str
     :param db_options: The database connection parameters.
     :type db_options: dict
-    :param mail_options: The email system parameters.
-    :type mail_options: dict
     :return 200 if OK, 500 in case of errors; a dictionary containing the
     new values from the update action.
     """
@@ -61,7 +59,7 @@ def complete_test_suite_import(
     name="import-sets-from-suite", ignore_result=False, add_to_parent=False)
 def import_test_sets_from_test_suite(
         prev_results,
-        suite_id, suite_name, tests_list, db_options, mail_options):
+        suite_id, suite_name, tests_list, db_options):
     """Import the test sets provided in a test suite.
 
     This task is linked from the test suite update one: the first argument is a
@@ -78,8 +76,6 @@ def import_test_sets_from_test_suite(
     :type tests_list: list
     :param db_options: The database connection parameters.
     :type db_options: dict
-    :param mail_options: The email system parameters.
-    :type mail_options: dict
     :return 200 if OK, 500 in case of errors; a dictionary with errors or an
     empty one.
     """
@@ -123,7 +119,7 @@ def import_test_sets_from_test_suite(
     name="import-cases-from-suite", ignore_result=False, add_to_parent=False)
 def import_test_cases_from_test_suite(
         prev_results,
-        suite_id, suite_name, tests_list, db_options, mail_options):
+        suite_id, suite_name, tests_list, db_options):
     """Import the test cases provided in a test suite.
 
     This task is linked from the test suite update one: the first argument is a
@@ -140,8 +136,6 @@ def import_test_cases_from_test_suite(
     :type tests_list: list
     :param db_options: The database connection parameters.
     :type db_options: dict
-    :param mail_options: The email system parameters.
-    :type mail_options: dict
     :return 200 if OK, 500 in case of errors; a dictionary with errors or an
     empty one.
     """
@@ -183,7 +177,7 @@ def import_test_cases_from_test_suite(
 
 @taskc.app.task(name="import-test-cases-from-set", ignore_result=False)
 def import_test_cases_from_test_set(
-        tests_list, suite_id, suite_name, set_id, db_options, mail_options):
+        tests_list, suite_id, suite_name, set_id, db_options):
     """Wrapper around the real import function.
 
     Import the test cases included in a test set.
@@ -198,8 +192,6 @@ def import_test_cases_from_test_set(
     :type set_id: bson.objectid.ObjectId
     :param db_options: The database connection parameters.
     :type db_options: dict
-    :param mail_options: The email system parameters.
-    :type mail_options: dict
     :return 200 if OK, 500 in case of errors; a dictionary with errors or an
     empty one.
     """
@@ -234,6 +226,7 @@ def update_test_suite_add_test_set_id(
 
     ret_val, errors = tests_import.update_test_suite_add_test_set_id(
         set_id, suite_id, suite_name,
-        taskc.app.conf.db_options, taskc.app.conf.mail_options)
+        taskc.app.conf.db_options,
+        taskc.app.conf.get("mail_options", None))
     # TODO: handle errors.
     return ret_val


### PR DESCRIPTION
Fix how email config options are being handled:

* remove all the mail options from the Tornado server config
* stop passing the mail options to the Celery tasks
* pass the mail options from the Celery config to the util functions

Note: a similar clean-up could be done for the `db_options`.