### PR TITLE
lava_log_parser.py: update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ netaddr==0.7.18
 pycares==1.0.0
 pymongo==2.8.1
 python-jenkins==0.4.11
+python-dateutil
 pytz
 pyyaml==3.12
 redis


### PR DESCRIPTION
Fix: 8e0b84a lava_log_parser.py: add timestamps to HTML log output

Update the requirements, add python-dateutil. Otherwise the package
is not installed in kernelci venv resulting in module import errors.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>