### PR TITLE
utils/callback: lava.py fix variable name cleanup

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -178,7 +178,7 @@ def _get_test_case_data(meta, tc_data, job_data, meta_data_map):
     tests = yaml.load(job_data["results"][test_key], Loader=yaml.CLoader)
     for test in tests:
         test_case = {}
-        for x, y in META_DATA_MAP.iteritems():
+        for x, y in meta_data_map.iteritems():
             try:
                 test_case.update({x: test[y]})
             except (KeyError) as ex:


### PR DESCRIPTION
Fix: 276fcffbfc89 Clean up global variable names and docstrings

One variable got missed in previous patch and was still in upper case.
Replace by lower case.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>