### PR TITLE
T7830 Fix boot regressions issue due to board instance name

### DIFF
--- a/app/utils/boot/regressions.py
+++ b/app/utils/boot/regressions.py
@@ -317,7 +317,6 @@ def check_and_track(boot_doc, db_options):
     # it's a new regression that we need to track.
     spec = {
         models.ARCHITECTURE_KEY: b_get(models.ARCHITECTURE_KEY),
-        models.BOARD_INSTANCE_KEY: b_get(models.BOARD_INSTANCE_KEY),
         models.BOARD_KEY: b_get(models.BOARD_KEY),
         models.COMPILER_VERSION_EXT_KEY:
             b_get(models.COMPILER_VERSION_EXT_KEY),


### PR DESCRIPTION
This may be a matter of opinion or consistency, but in practice using the board instance name effectively hides away some regressions.  I see this easily with my 2 qemu devices, they run jobs alternatively so if I start with a "good" boot run on qemu0 and then run a "bad" boot on qemu1, it won't be detected as a regression unless this change is applied (or I'm lucky and an earlier good boot of the same kind was run on qemu1).