### PR TITLE
T7885 Separate tests from boots

### DIFF
--- a/app/handlers/callback.py
+++ b/app/handlers/callback.py
@@ -143,26 +143,28 @@ class LavaCallbackHandler(CallbackHandler):
         return models.LAVA_CALLBACK_VALID_KEYS.get(method, None)
 
     def _execute_callback(self, lab_name, **kwargs):
-        response = hresponse.HandlerResponse()
         action = kwargs["action"]
         json_obj = kwargs["json_obj"]
-        tasks = []
+        response = hresponse.HandlerResponse()
+        response.status_code = 202
+        response.reason = "Request accepted and being processed"
 
         if action in ["boot", "test"]:
-            tasks.append(taskqueue.tasks.callback.lava_boot.s(
-                json_obj, lab_name))
-            tasks.append(taskqueue.tasks.boot.find_regression.s())
-
-        if action == "test":
-            tasks.append(taskqueue.tasks.callback.lava_test.s(
-                json_obj, lab_name))
-
-        if not tasks:
+            tasks = [
+                taskqueue.tasks.callback.lava_test.s(json_obj, lab_name),
+            ]
+            chain(tasks).apply_async(
+                link_error=taskqueue.tasks.error_handler.s())
+        else:
             response.status_code = 404
             response.reason = "Unsupported LAVA action: {}".format(action)
-        else:
-            response.status_code = 202
-            response.reason = "Request accepted and being processed"
+
+        # Also run the legacy boot callback to generate boot entries
+        if action == "boot":
+            tasks = [
+                taskqueue.tasks.callback.lava_boot.s(json_obj, lab_name),
+                taskqueue.tasks.boot.find_regression.s(),
+            ]
             chain(tasks).apply_async(
                 link_error=taskqueue.tasks.error_handler.s())
 

--- a/app/models/test_suite.py
+++ b/app/models/test_suite.py
@@ -52,7 +52,6 @@ class TestSuiteDocument(modb.BaseDocument):
         self.arch = None
         self.board = None
         self.board_instance = None
-        self.boot_id = None
         self.defconfig = None
         self.defconfig_full = None
         self.definition_uri = None
@@ -119,7 +118,6 @@ class TestSuiteDocument(modb.BaseDocument):
             models.ARCHITECTURE_KEY: self.arch,
             models.BOARD_INSTANCE_KEY: self.board_instance,
             models.BOARD_KEY: self.board,
-            models.BOOT_ID_KEY: self.boot_id,
             models.BUILD_ID_KEY: self.build_id,
             models.CREATED_KEY: self.created_on,
             models.DEFCONFIG_FULL_KEY: self.defconfig_full or self.defconfig,

--- a/app/models/test_suite.py
+++ b/app/models/test_suite.py
@@ -28,42 +28,61 @@ class TestSuiteDocument(modb.BaseDocument):
     A test suite is a document that can store test cases and/or test sets ran.
     """
 
-    def __init__(self, name, lab_name, build_id=None, version="1.0"):
+    def __init__(self, name, lab_name):
         """The test suite document.
 
         :param name: The name given to this test suite.
         :type name: string
         :param lab_name: The name of the lab running this test suite.
         :type lab_name: str
-        :param build_id: The ID of the defconfig associated with this
-        test suite.
-        :type build_id: str
-        :param version: The version of the JSON schema of this test suite.
-        :type version: str
         """
-        self._created_on = None
-        self._id = None
         self._name = name
-        self._version = version
-
-        self.build_id = build_id
-        self.lab_name = lab_name
+        self._lab_name = lab_name
+        self._build_id = None
+        self._version = None
+        self._id = None
+        self._created_on = None
 
         self.arch = None
         self.board = None
         self.board_instance = None
+        self.boot_log = None
+        self.boot_log_html = None
+        self.boot_result_description = None
+        self.compiler = None
+        self.compiler_version = None
+        self.compiler_version_full = None
+        self.cross_compile = None
         self.defconfig = None
         self.defconfig_full = None
         self.definition_uri = None
+        self.device_type = None
+        self.dtb = None
+        self.dtb_addr = None
+        self.endian = None
+        self.file_server_resource = None
+        self.file_server_url = None
         self.git_branch = None
+        self.git_commit = None
+        self.git_describe = None
+        self.git_url = None
+        self.initrd_addr = None
         self.job = None
         self.job_id = None
         self.kernel = None
+        self.kernel_image = None
+        self.kernel_image_size = None
+        self.load_addr = None
+        self.mach = None
         self.metadata = {}
+        self.qemu = None
+        self.qemu_command = None
+        self.retries = 0
         self.test_case = []
         self.test_set = []
         self.time = -1
         self.vcs_commit = None
+        self.warnings = 0
 
     @property
     def collection(self):
@@ -74,24 +93,22 @@ class TestSuiteDocument(modb.BaseDocument):
         """The name of the test suite."""
         return self._name
 
-    @name.setter
-    def name(self, value):
-        """Set the name of the test suite.
-
-        :param value: The name of the test suite.
-        :type value: string
-        """
-        self._name = value
+    @property
+    def lab_name(self):
+        """The name of the test lab."""
+        return self._lab_name
 
     @property
-    def id(self):
-        """The ID of the test suite as registered in the database."""
-        return self._id
+    def build_id(self):
+        """The ID of the build."""
+        return self._build_id
 
-    @id.setter
-    def id(self, value):
-        """Set the test suite ID."""
-        self._id = value
+    @build_id.setter
+    def build_id(self, value):
+        """Set the ID of the build."""
+        if self._build_id:
+            raise AttributeError("Build ID already set")
+        self._build_id = value
 
     @property
     def version(self):
@@ -101,7 +118,21 @@ class TestSuiteDocument(modb.BaseDocument):
     @version.setter
     def version(self, value):
         """Set the schema version of this test suite."""
+        if self._version:
+            raise AttributeError("Schema version already set")
         self._version = value
+
+    @property
+    def id(self):
+        """The ID of the test suite as registered in the database."""
+        return self._id
+
+    @id.setter
+    def id(self, value):
+        """Set the test suite ID."""
+        if self._id:
+            raise AttributeError("ID already set")
+        self._id = value
 
     @property
     def created_on(self):
@@ -111,36 +142,59 @@ class TestSuiteDocument(modb.BaseDocument):
     @created_on.setter
     def created_on(self, value):
         """Set the creation date of this test suite."""
+        if self._created_on:
+            raise AttributeError("Creation date already set")
         self._created_on = value
 
     def to_dict(self):
-        test_suite = {
+        return {
             models.ARCHITECTURE_KEY: self.arch,
             models.BOARD_INSTANCE_KEY: self.board_instance,
             models.BOARD_KEY: self.board,
+            models.BOOT_LOG_KEY: self.boot_log,
+            models.BOOT_LOG_HTML_KEY: self.boot_log_html,
+            models.BOOT_RESULT_DESC_KEY: self.boot_result_description,
             models.BUILD_ID_KEY: self.build_id,
+            models.COMPILER_KEY: self.compiler,
+            models.COMPILER_VERSION_FULL_KEY: self.compiler_version_full,
+            models.COMPILER_VERSION_KEY: self.compiler_version,
+            models.CROSS_COMPILE_KEY: self.cross_compile,
             models.CREATED_KEY: self.created_on,
             models.DEFCONFIG_FULL_KEY: self.defconfig_full or self.defconfig,
             models.DEFCONFIG_KEY: self.defconfig,
             models.DEFINITION_URI_KEY: self.definition_uri,
+            models.DEVICE_TYPE_KEY: self.device_type,
+            models.DTB_KEY: self.dtb,
+            models.DTB_ADDR_KEY: self.dtb_addr,
+            models.ENDIANNESS_KEY: self.endian,
+            models.FILE_SERVER_RESOURCE_KEY: self.file_server_resource,
+            models.FILE_SERVER_URL_KEY: self.file_server_url,
             models.GIT_BRANCH_KEY: self.git_branch,
+            models.GIT_COMMIT_KEY: self.git_commit,
+            models.GIT_DESCRIBE_KEY: self.git_describe,
+            models.GIT_URL_KEY: self.git_url,
+            models.ID_KEY: self.id,
+            models.INITRD_ADDR_KEY: self.initrd_addr,
             models.JOB_ID_KEY: self.job_id,
             models.JOB_KEY: self.job,
             models.KERNEL_KEY: self.kernel,
+            models.KERNEL_IMAGE_KEY: self.kernel_image,
+            models.KERNEL_IMAGE_SIZE_KEY: self.kernel_image_size,
             models.LAB_NAME_KEY: self.lab_name,
+            models.LOAD_ADDR_KEY: self.load_addr,
+            models.MACH_KEY: self.mach,
             models.METADATA_KEY: self.metadata,
+            models.QEMU_KEY: self.qemu,
+            models.QEMU_COMMAND_KEY: self.qemu_command,
+            models.RETRIES_KEY: self.retries,
             models.NAME_KEY: self.name,
             models.TEST_CASE_KEY: self.test_case,
             models.TEST_SET_KEY: self.test_set,
             models.TIME_KEY: self.time,
             models.VCS_COMMIT_KEY: self.vcs_commit,
-            models.VERSION_KEY: self.version
+            models.VERSION_KEY: self.version,
+            models.WARNINGS_KEY: self.warnings,
         }
-
-        if self.id:
-            test_suite[models.ID_KEY] = self.id
-
-        return test_suite
 
     @staticmethod
     def from_json(json_obj):
@@ -149,16 +203,10 @@ class TestSuiteDocument(modb.BaseDocument):
             local_obj = copy.deepcopy(json_obj)
             doc_pop = local_obj.pop
 
-            suite_id = doc_pop(models.ID_KEY, None)
-
             try:
                 name = doc_pop(models.NAME_KEY)
                 lab_name = doc_pop(models.LAB_NAME_KEY)
-                build_id = doc_pop(models.BUILD_ID_KEY)
-
-                test_suite = TestSuiteDocument(name, lab_name, build_id)
-                test_suite.id = suite_id
-
+                test_suite = TestSuiteDocument(name, lab_name)
                 for key, val in local_obj.iteritems():
                     setattr(test_suite, key, val)
             except KeyError:

--- a/app/models/tests/test_test_suite_model.py
+++ b/app/models/tests/test_test_suite_model.py
@@ -20,56 +20,104 @@ import models.test_suite as mtsuite
 class TestTestSuiteModel(unittest.TestCase):
 
     def test_suite_doc_valid_instance(self):
-        test_suite = mtsuite.TestSuiteDocument(
-            "name", "lab_name", "build_id", "1.0")
+        test_suite = mtsuite.TestSuiteDocument("name", "lab-name")
         self.assertIsInstance(test_suite, mbase.BaseDocument)
 
     def test_suite_doc_to_dict(self):
-        test_suite = mtsuite.TestSuiteDocument(
-            "name", "lab_name", "build_id", "1.0")
+        test_suite = mtsuite.TestSuiteDocument("name", "lab-name")
 
         test_suite.arch = "arm"
         test_suite.board = "board"
         test_suite.board_instance = 1
+        test_suite.boot_log = "boot-log"
+        test_suite.boot_log_html = "boot-log-html"
+        test_suite.boot_result_description = "boot-result-description"
+        test_suite.build_id = "build-id"
+        test_suite.compiler = "gcc"
+        test_suite.compiler_version = "4.7.3"
+        test_suite.compiler_version_full = "gcc version 4.7.3"
         test_suite.created_on = "now"
+        test_suite.cross_compile = "cross-compile"
         test_suite.defconfig = "defconfig"
-        test_suite.build_id = "another_build-id"
+        test_suite.defconfig_full = "defconfig-full"
         test_suite.definition_uri = "uri"
-        test_suite.git_branch = "git_branch"
+        test_suite.device_type = "device-type"
+        test_suite.dtb = "dtb"
+        test_suite.dtb_addr = "dtb-addr"
+        test_suite.endian = "big-endian"
+        test_suite.file_server_resource = "file-resource"
+        test_suite.file_server_url = "file-url"
+        test_suite.git_branch = "git-branch"
+        test_suite.git_commit = "git-commit"
+        test_suite.git_describe = "git-describe"
+        test_suite.git_url = "git-url"
         test_suite.id = "id"
+        test_suite.initrd_addr = "initrd-addr"
         test_suite.job = "job"
         test_suite.job_id = "job_id"
         test_suite.kernel = "kernel"
-        test_suite.lab_name = "another_lab"
+        test_suite.kernel_image = "kernel-image"
+        test_suite.kernel_image_size = "kernel-image-size"
+        test_suite.load_addr = "load-addr"
+        test_suite.mach = "mach"
         test_suite.metadata = {"foo": "bar"}
+        test_suite.qemu = "qemu"
+        test_suite.qemu_command = "qemu-command"
+        test_suite.retries = 2
         test_suite.test_case = ["foo"]
         test_suite.test_set = ["bar"]
         test_suite.time = 10
         test_suite.vcs_commit = "1234"
         test_suite.version = "1.1"
+        test_suite.warnings = 123
 
         expected = {
             "_id": "id",
             "arch": "arm",
             "board": "board",
             "board_instance": 1,
+            "boot_log": "boot-log",
+            "boot_log_html": "boot-log-html",
+            "boot_result_description": "boot-result-description",
+            "build_id": "build-id",
+            "compiler": "gcc",
+            "compiler_version": "4.7.3",
+            "compiler_version_full": "gcc version 4.7.3",
             "created_on": "now",
+            "cross_compile": "cross-compile",
             "defconfig": "defconfig",
-            "defconfig_full": "defconfig",
-            "build_id": "another_build-id",
+            "defconfig_full": "defconfig-full",
             "definition_uri": "uri",
-            "git_branch": "git_branch",
+            "device_type": "device-type",
+            "dtb": "dtb",
+            "dtb_addr": "dtb-addr",
+            "endian": "big-endian",
+            "file_server_resource": "file-resource",
+            "file_server_url": "file-url",
+            "git_branch": "git-branch",
+            "git_commit": "git-commit",
+            "git_describe": "git-describe",
+            "git_url": "git-url",
+            "initrd_addr": "initrd-addr",
             "job": "job",
             "job_id": "job_id",
             "kernel": "kernel",
-            "lab_name": "another_lab",
+            "kernel_image": "kernel-image",
+            "kernel_image_size": "kernel-image-size",
+            "lab_name": "lab-name",
+            "load_addr": "load-addr",
+            "mach": "mach",
             "metadata": {"foo": "bar"},
             "name": "name",
+            "qemu": "qemu",
+            "qemu_command": "qemu-command",
+            "retries": 2,
             "test_case": ["foo"],
             "test_set": ["bar"],
             "time": 10,
             "vcs_commit": "1234",
-            "version": "1.1"
+            "version": "1.1",
+            "warnings": 123,
         }
 
         self.assertDictEqual(expected, test_suite.to_dict())
@@ -92,36 +140,51 @@ class TestTestSuiteModel(unittest.TestCase):
             "arch": "arm",
             "board": "board",
             "board_instance": 1,
+            "boot_log": None,
+            "boot_log_html": None,
+            "boot_result_description": None,
+            "build_id": "build-id",
+            "compiler": None,
+            "compiler_version": None,
+            "compiler_version_full": None,
             "created_on": "now",
+            "cross_compile": None,
             "defconfig": "defconfig",
             "defconfig_full": "defconfig",
-            "build_id": "build-id",
             "definition_uri": "uri",
+            "device_type": "device-type",
+            "dtb": None,
+            "dtb_addr": None,
+            "endian": None,
+            "file_server_resource": None,
+            "file_server_url": None,
             "git_branch": "git_branch",
+            "git_commit": "git_commit",
+            "git_describe": "git_describe",
+            "git_url": "git_url",
+            "initrd_addr": "initrd_addr",
             "job": "job",
             "job_id": "job_id",
             "kernel": "kernel",
-            "lab_name": "lab_name",
+            "kernel_image": None,
+            "kernel_image_size": None,
+            "lab_name": "lab-name",
+            "load_addr": "load_addr",
+            "mach": "mach",
             "metadata": {"foo": "bar"},
             "name": "name",
+            "qemu": None,
+            "qemu_command": None,
+            "retries": 0,
             "test_case": ["foo"],
             "test_set": ["bar"],
             "time": 10,
             "vcs_commit": "1234",
-            "version": "1.0"
+            "version": "1.0",
+            "warnings": 123,
         }
 
         test_suite = mtsuite.TestSuiteDocument.from_json(suite_json)
 
         self.assertIsInstance(test_suite, mtsuite.TestSuiteDocument)
         self.assertDictEqual(suite_json, test_suite.to_dict())
-
-    def test_set_name_setter(self):
-        test_suite = mtsuite.TestSuiteDocument(
-            "name", "lab_name", "build_id", "1.0")
-
-        def test_name_setter(value):
-            test_suite.name = value
-
-        test_name_setter("foo")
-        self.assertEqual("foo", test_suite.name)

--- a/app/models/tests/test_test_suite_model.py
+++ b/app/models/tests/test_test_suite_model.py
@@ -31,7 +31,6 @@ class TestTestSuiteModel(unittest.TestCase):
         test_suite.arch = "arm"
         test_suite.board = "board"
         test_suite.board_instance = 1
-        test_suite.boot_id = "boot_id"
         test_suite.created_on = "now"
         test_suite.defconfig = "defconfig"
         test_suite.build_id = "another_build-id"
@@ -54,7 +53,6 @@ class TestTestSuiteModel(unittest.TestCase):
             "arch": "arm",
             "board": "board",
             "board_instance": 1,
-            "boot_id": "boot_id",
             "created_on": "now",
             "defconfig": "defconfig",
             "defconfig_full": "defconfig",
@@ -94,7 +92,6 @@ class TestTestSuiteModel(unittest.TestCase):
             "arch": "arm",
             "board": "board",
             "board_instance": 1,
-            "boot_id": "boot_id",
             "created_on": "now",
             "defconfig": "defconfig",
             "defconfig_full": "defconfig",

--- a/app/taskqueue/tasks/callback.py
+++ b/app/taskqueue/tasks/callback.py
@@ -36,13 +36,11 @@ def lava_boot(json_obj, lab_name):
 
 
 @taskc.app.task(name="lava-test")
-def lava_test(boot_doc_id, json_obj, lab_name):
+def lava_test(json_obj, lab_name):
     """Add test data from a LAVA v2 test job callback
 
     This is a wrapper around the actual function which runs in a Celery task.
 
-    :param boot_doc_id: The boot document object id associated with this test.
-    :type boot_doc_id: ObjectId
     :param json_obj: The JSON object with the values necessary to import the
     LAVA test data.
     :type json_obj: dictionary
@@ -50,5 +48,5 @@ def lava_test(boot_doc_id, json_obj, lab_name):
     :type lab_name: string
     :return ObjectId The test document object id.
     """
-    return utils.callback.lava.add_tests(json_obj, lab_name, boot_doc_id,
+    return utils.callback.lava.add_tests(json_obj, lab_name,
                                          taskc.app.conf.db_options)

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -344,8 +344,7 @@ def _get_test_case_data(suite_results, suite_name):
     return test_cases
 
 
-def add_tests(job_data, lab_name, boot_doc_id,
-              db_options, base_path=utils.BASE_PATH):
+def add_tests(job_data, lab_name, db_options, base_path=utils.BASE_PATH):
     """Entry point to be used as an external task.
 
     This function should only be called by Celery or other task managers.
@@ -356,13 +355,11 @@ def add_tests(job_data, lab_name, boot_doc_id,
     :type job_data: dict
     :param lab_name: Name of the LAVA lab that posted the callback.
     :type lab_name: string
-    :param boot_doc_id: The ID of the boot document related to this test suite
-    :type boot_doc_id: str
     :param db_options: The mongodb database connection parameters.
     :type db_options: dict
     :param base_path: Path to the top-level directory where to save files.
     :type base_path: string
-    :return tuple The return code, the boot document id and errors.
+    :return tuple The return code, the test document id and errors.
     """
     ret_code = 201
     suite_doc_id = None
@@ -383,7 +380,6 @@ def add_tests(job_data, lab_name, boot_doc_id,
         suite_data = {
             models.VERSION_KEY: "1.0",
             models.LAB_NAME_KEY: lab_name,
-            models.BOOT_ID_KEY: boot_doc_id,
             models.TIME_KEY: "0.0",
             models.NAME_KEY: suite_name,
         }

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -51,14 +51,23 @@ TEST_CASE_NAME_EXTRA = {
 }
 
 META_DATA_MAP_TEST_SUITE = {
-    models.DEFCONFIG_KEY: "kernel.defconfig_base",
-    models.DEFCONFIG_FULL_KEY: "kernel.defconfig",
-    models.GIT_BRANCH_KEY: "git.branch",
-    models.VCS_COMMIT_KEY: "git.commit",
-    models.KERNEL_KEY: "kernel.version",
-    models.JOB_KEY: "kernel.tree",
     models.ARCHITECTURE_KEY: "job.arch",
     models.BOARD_KEY: "platform.name",
+    models.DEFCONFIG_KEY: "kernel.defconfig_base",
+    models.DEFCONFIG_FULL_KEY: "kernel.defconfig",
+    models.DEVICE_TYPE_KEY: "device.type",
+    models.DTB_KEY: "platform.dtb",
+    models.ENDIANNESS_KEY: "kernel.endian",
+    models.GIT_BRANCH_KEY: "git.branch",
+    models.GIT_COMMIT_KEY: "git.commit",
+    models.GIT_DESCRIBE_KEY: "git.describe",
+    models.GIT_URL_KEY: "git.url",
+    models.INITRD_KEY: "job.initrd_url",
+    models.JOB_KEY: "kernel.tree",
+    models.KERNEL_KEY: "kernel.version",
+    models.KERNEL_IMAGE_KEY: "job.kernel_image",
+    models.MACH_KEY: "platform.mach",
+    models.VCS_COMMIT_KEY: "git.commit",
 }
 
 META_DATA_MAP_BOOT = {
@@ -88,6 +97,20 @@ BL_META_MAP = {
 }
 
 
+def _get_job_meta(meta, job_data):
+    """Parse the main job meta-data from LAVA
+
+    :param meta: The meta-data to populate.
+    :type meta: dictionary
+    :param job_data: The JSON data from the callback.
+    :type job_data: dict
+    :param job_data: The map of keys to search for in the JSON and update.
+    :type job_data: dict
+    """
+    meta[models.BOOT_RESULT_KEY] = LAVA_JOB_RESULT[job_data["status"]]
+    meta[models.BOARD_INSTANCE_KEY] = job_data["actual_device_id"]
+
+
 def _get_definition_meta(meta, job_data, meta_data_map):
     """Parse the job definition meta-data from LAVA
 
@@ -103,7 +126,6 @@ def _get_definition_meta(meta, job_data, meta_data_map):
     :param meta_data_map: The dict of keys to parse and add in the meta-data.
     :type meta_data_map: dict
     """
-    meta[models.BOARD_INSTANCE_KEY] = job_data["actual_device_id"]
     definition = yaml.load(job_data["definition"], Loader=yaml.CLoader)
     job_meta = definition["metadata"]
     for x, y in meta_data_map.iteritems():
@@ -194,7 +216,7 @@ def _get_lava_meta(meta, job_data):
             handler(meta, step["metadata"])
 
 
-def _add_boot_log(meta, log, base_path):
+def _add_boot_log(meta, job_log, base_path, name):
     """Parse and save kernel logs
 
     Parse the kernel boot log in YAML format from a LAVA v2 job and save it as
@@ -207,7 +229,7 @@ def _add_boot_log(meta, log, base_path):
     :param base_path: Path to the top-level directory where to store the files.
     :type base_path: string
     """
-    log = yaml.load(log, Loader=yaml.CLoader)
+    log = yaml.load(job_log, Loader=yaml.CLoader)
 
     dir_path = os.path.join(
         base_path,
@@ -218,8 +240,8 @@ def _add_boot_log(meta, log, base_path):
         meta[models.DEFCONFIG_FULL_KEY],
         meta[models.LAB_NAME_KEY])
 
-    utils.LOG.info("Generating boot log files in {}".format(dir_path))
-    file_name = "-".join(["boot", meta[models.BOARD_KEY]])
+    utils.LOG.info("Generating {} log files in {}".format(name, dir_path))
+    file_name = "-".join([name, meta[models.BOARD_KEY]])
     files = tuple(".".join([file_name, ext]) for ext in ["txt", "html"])
     meta[models.BOOT_LOG_KEY], meta[models.BOOT_LOG_HTML_KEY] = files
     txt_path, html_path = (os.path.join(dir_path, f) for f in files)
@@ -269,10 +291,10 @@ def add_boot(job_data, lab_name, db_options, base_path=utils.BASE_PATH):
     msg = None
 
     try:
-        meta[models.BOOT_RESULT_KEY] = LAVA_JOB_RESULT[job_data["status"]]
+        _get_job_meta(meta, job_data)
         _get_definition_meta(meta, job_data, META_DATA_MAP_BOOT)
         _get_lava_meta(meta, job_data)
-        _add_boot_log(meta, job_data["log"], base_path)
+        _add_boot_log(meta, job_data["log"], base_path, "boot")
         doc_id = utils.boot.import_and_save_boot(meta, db_options)
     except (yaml.YAMLError, ValueError) as ex:
         ret_code = 400
@@ -387,7 +409,10 @@ def add_tests(job_data, lab_name, db_options, base_path=utils.BASE_PATH):
         utils.LOG.info("Processing test suite: {}".format(suite_name))
 
         try:
+            _get_job_meta(suite_data, job_data)
             _get_definition_meta(suite_data, job_data, META_DATA_MAP_TEST_SUITE)
+            _get_lava_meta(suite_data, job_data)
+            _add_boot_log(suite_data, job_data["log"], base_path, suite_name)
             case_data = _get_test_case_data(suite_results, suite_name)
             ret_code, suite_doc_id, err = \
                 utils.kci_test.import_and_save_kci_test(

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -443,9 +443,7 @@ def _parse_test_suite_from_json(test_json, database, errors):
         ERR_ADD(errors, 400, err_msg)
         return None
 
-    test_doc = mtest_suite.TestSuiteDocument(
-        name=name,
-        lab_name=lab_name)
+    test_doc = mtest_suite.TestSuiteDocument(name, lab_name)
     test_doc.created_on = datetime.datetime.now(
         tz=bson.tz_util.utc)
     _update_test_suite_doc_from_json(test_doc, test_json, errors)

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -47,7 +47,14 @@ NON_NULL_KEYS_CASE = [
 ]
 
 SPEC_TEST_SUITE = {
-    models.BOOT_ID_KEY: "boot_id",
+    models.ARCHITECTURE_KEY: "arch",
+    models.BOARD_KEY: "board",
+    models.DEFCONFIG_FULL_KEY: "defconfig_full",
+    models.DEFCONFIG_KEY: "defconfig",
+    models.GIT_BRANCH_KEY: "git_branch",
+    models.JOB_KEY: "job",
+    models.KERNEL_KEY: "kernel",
+    models.LAB_NAME_KEY: "lab_name",
     models.NAME_KEY: "name",
 }
 
@@ -88,14 +95,12 @@ def save_or_update(doc, spec_map, collection, database, errors):
     :type errors: dict
     :return The save action return code and the doc ID.
     """
-    spec = {}
+    spec = {x: getattr(doc, y) for x, y in spec_map.iteritems()}
 
     fields = [
         models.CREATED_KEY,
         models.ID_KEY,
     ]
-
-    spec.update({x: getattr(doc, y) for x, y in spec_map.iteritems()})
 
     prev_doc = utils.db.find_one2(
         database[collection], spec, fields=fields)
@@ -334,15 +339,43 @@ def _update_test_suite_doc_from_json(suite_doc, test_dict, errors):
     suite_doc.arch = test_dict.get(models.ARCHITECTURE_KEY, None)
     suite_doc.board = test_dict.get(models.BOARD_KEY, None)
     suite_doc.board_instance = test_dict.get(models.BOARD_INSTANCE_KEY, None)
-    suite_doc.boot_id = test_dict.get(models.BOOT_ID_KEY, None)
+    suite_doc.boot_log = test_dict.get(models.BOOT_LOG_KEY, None)
+    suite_doc.boot_log_html = test_dict.get(models.BOOT_LOG_HTML_KEY, None)
+    suite_doc.boot_result_description = test_dict.get(
+        models.BOOT_RESULT_DESC_KEY, None)
+    suite_doc.dtb = test_dict.get(models.DTB_KEY, None)
+    suite_doc.dtb_addr = test_dict.get(models.DTB_ADDR_KEY, None)
+    suite_doc.device_type = test_dict.get(models.DEVICE_TYPE_KEY, None)
     suite_doc.defconfig = test_dict.get(models.DEFCONFIG_KEY, None)
     suite_doc.defconfig_full = test_dict.get(models.DEFCONFIG_FULL_KEY, None)
+    suite_doc.endian = test_dict.get(models.ENDIANNESS_KEY, None)
+    suite_doc.file_server_resource = test_dict.get(
+        models.FILE_SERVER_RESOURCE_KEY, None)
+    suite_doc.file_server_url = test_dict.get(models.FILE_SERVER_URL_KEY, None)
     suite_doc.git_branch = test_dict.get(models.GIT_BRANCH_KEY, None)
+    suite_doc.git_commit = test_dict.get(models.GIT_COMMIT_KEY, None)
+    suite_doc.git_describe = test_dict.get(models.GIT_DESCRIBE_KEY, None)
+    suite_doc.git_url = test_dict.get(models.GIT_URL_KEY, None)
+    suite_doc.initrd_addr = test_dict.get(models.INITRD_ADDR_KEY, None)
     suite_doc.job = test_dict.get(models.JOB_KEY, None)
     suite_doc.kernel = test_dict.get(models.KERNEL_KEY, None)
+    suite_doc.kernel_image = test_dict.get(models.KERNEL_IMAGE_KEY, None)
+    suite_doc.kernel_image_size = test_dict.get(
+        models.KERNEL_IMAGE_SIZE_KEY, None)
+    suite_doc.load_addr = test_dict.get(models.BOOT_LOAD_ADDR_KEY, None)
     suite_doc.metadata = test_dict.get(models.METADATA_KEY, {})
+    suite_doc.qemu = test_dict.get(models.QEMU_KEY, None)
+    suite_doc.qemu_command = test_dict.get(models.QEMU_COMMAND_KEY, None)
+    suite_doc.retries = test_dict.get(models.BOOT_RETRIES_KEY, 0)
+    suite_doc.uimage = test_dict.get(models.UIMAGE_KEY, None)
+    suite_doc.uimage_addr = test_dict.get(models.UIMAGE_ADDR_KEY, None)
     suite_doc.vcs_commit = test_dict.get(models.VCS_COMMIT_KEY, None)
     suite_doc.version = test_dict.get(models.VERSION_KEY, "1.0")
+    suite_doc.warnings = test_dict.get(models.BOOT_WARNINGS_KEY, 0)
+
+    # mach_alias_key takes precedence if defined
+    suite_doc.mach = test_dict.get(
+        models.MACH_ALIAS_KEY, test_dict.get(models.MACH_KEY, None))
 
 
 def _update_test_suite_doc_ids(suite_doc, database):
@@ -394,8 +427,24 @@ def _update_test_suite_doc_ids(suite_doc, database):
         if all([not suite_doc.job_id, doc_get(models.JOB_ID_KEY, None)]):
             suite_doc.job_id = doc_get(models.JOB_ID_KEY, None)
         # Get also git information if we do not have them already,
+        if not suite_doc.compiler:
+            suite_doc.compiler = doc_get(models.COMPILER_KEY, None)
+        if not suite_doc.compiler_version:
+            suite_doc.compiler_version = \
+                doc_get(models.COMPILER_VERSION_KEY, None)
+        if not suite_doc.compiler_version_full:
+            suite_doc.compiler_version_full = \
+                doc_get(models.COMPILER_VERSION_FULL_KEY, None)
+        if not suite_doc.cross_compile:
+            suite_doc.cross_compile = doc_get(models.CROSS_COMPILE_KEY, None)
         if not suite_doc.git_branch:
             suite_doc.git_branch = doc_get(models.GIT_BRANCH_KEY, None)
+        if not suite_doc.git_commit:
+            suite_doc.git_commit = doc_get(models.GIT_COMMIT_KEY, None)
+        if not suite_doc.git_describe:
+            suite_doc.git_describe = doc_get(models.GIT_DESCRIBE_KEY, None)
+        if not suite_doc.git_url:
+            suite_doc.git_url = doc_get(models.GIT_URL_KEY, None)
         if not suite_doc.vcs_commit:
             suite_doc.vcs_commit = doc_get(models.GIT_COMMIT_KEY, None)
     else:
@@ -444,8 +493,7 @@ def _parse_test_suite_from_json(test_json, database, errors):
         return None
 
     test_doc = mtest_suite.TestSuiteDocument(name, lab_name)
-    test_doc.created_on = datetime.datetime.now(
-        tz=bson.tz_util.utc)
+    test_doc.created_on = datetime.datetime.now(tz=bson.tz_util.utc)
     _update_test_suite_doc_from_json(test_doc, test_json, errors)
     _update_test_suite_doc_ids(test_doc, database)
     return test_doc


### PR DESCRIPTION
Separate test entries in the database from boot entries so they can evolve separately and avoid any cross-talk between test and boot results.

* add fields to the test entries with some boot meta-data
* always create a test entry when receiving either a test or a boot callback
* do not create a boot entry when receiving a test callback
* use the test suite name in the generated logs
* only look for regressions when receiving a boot callback for now