### PR TITLE
utils/callback: lava.py store raw json data from LAVA callbacks

### DIFF
--- a/app/utils/scripts/fake_lava_v2_callback.py
+++ b/app/utils/scripts/fake_lava_v2_callback.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import requests
+import sys
+import json
+import argparse
+
+
+def fake_callback(backend_url, lab_name, lab_token, filename):
+    headers = {
+        "Authorization": lab_token
+    }
+    print "Looking for file {}".format(filename)
+    try:
+        json_file = open(filename)
+    except (IOError) as err:
+        print "Can't find file, error: {}".format(err)
+        return
+    payload = json.load(json_file)
+    url = backend_url + "/callback/lava/boot?lab_name=" + lab_name + "&status=2&status_string=complete"
+    response = requests.post(url, headers=headers, json=payload)
+    print response
+
+
+def parse_cmdline():
+    parser = argparse.ArgumentParser(
+        description="Resend a LAVA v2 callback event from a JSON file",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--url', action='store',
+                        help="The backend url to send callbacks to",
+                        required=True)
+    parser.add_argument('--lab-name', action='store',
+                        help="The lab-name as registered in the backend.",
+                        required=True)
+    parser.add_argument('--token', action='store',
+                        help="The token associated to the lab-name",
+                        required=True)
+    parser.add_argument('--filename', action='store',
+                        help="The json file that contains the callback data.",
+                        required=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_cmdline()
+    fake_callback(args.url, args.lab_name, args.token, args.filename)
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)


### PR DESCRIPTION
Add a utility that stores the raw test data from a LAVA v2 callback.

It would be very usefull to have this kind of data stored along with the
logs. This can help debug issues happening on the frontend / backend by
replaying them. It can also help in development to fake callback events
and make sure there was no regression.

The raw json data from LAVA callback is stored in a folder called
"json-raw", with the default PATH being the utils.BASE_PATH.

Beforing storing the data, sensitive information such as the token used
to send the callback is removed. A link to the boot_log, lab_name and
version is also added for further use.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>