### PR TITLE
Fix boot warnings when parsing LAVA v2 callback

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -151,7 +151,7 @@ def _get_lava_boot_meta(meta, boot_meta):
                 if msg:
                     kernel_messages.append(msg)
     if kernel_messages:
-        meta[models.BOOT_WARNINGS_KEY] = kernel_messages
+        meta[models.BOOT_WARNINGS_KEY] = len(kernel_messages)
 
 
 def _get_lava_bootloader_meta(meta, bl_meta):


### PR DESCRIPTION
The boot warnings field is meant to hold the number of warnings, not
the actual warning messages.  Fix this by storing the length of the
list of warnings found.

Fixes #46.