### PR TITLE
TestSuite: fix new document ids

### DIFF
--- a/app/models/test_suite.py
+++ b/app/models/test_suite.py
@@ -147,7 +147,7 @@ class TestSuiteDocument(modb.BaseDocument):
         self._created_on = value
 
     def to_dict(self):
-        return {
+        test_suite = {
             models.ARCHITECTURE_KEY: self.arch,
             models.BOARD_INSTANCE_KEY: self.board_instance,
             models.BOARD_KEY: self.board,
@@ -173,7 +173,6 @@ class TestSuiteDocument(modb.BaseDocument):
             models.GIT_COMMIT_KEY: self.git_commit,
             models.GIT_DESCRIBE_KEY: self.git_describe,
             models.GIT_URL_KEY: self.git_url,
-            models.ID_KEY: self.id,
             models.INITRD_ADDR_KEY: self.initrd_addr,
             models.JOB_ID_KEY: self.job_id,
             models.JOB_KEY: self.job,
@@ -195,6 +194,11 @@ class TestSuiteDocument(modb.BaseDocument):
             models.VERSION_KEY: self.version,
             models.WARNINGS_KEY: self.warnings,
         }
+
+        if self.id:
+            test_suite[models.ID_KEY] = self.id
+
+        return test_suite
 
     @staticmethod
     def from_json(json_obj):


### PR DESCRIPTION
New document IDs are only generated when there is no ID key at all in
the new object's dictionary when passed to utils.db.save() - having a
key set to None results in a null key in the database.  Fix this by
reverting to only adding an ID key when the object already has a valid
ID.

Fixes: 21f1eb56e714 ("Add boot meta-data to TestSuiteDocument")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>