### PR TITLE
T8524 Use the KERNEL_TREE Jenkins parameter for bisections

### DIFF
--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -495,7 +495,7 @@ def _start_bisection(bisection, jopts):
         "DEFCONFIG": models.DEFCONFIG_FULL_KEY,
         "TARGET": models.DEVICE_TYPE_KEY,
         "LAB": models.LAB_NAME_KEY,
-        "TREE": models.JOB_KEY,
+        "KERNEL_TREE": models.JOB_KEY,
         "GOOD_COMMIT": models.GIT_COMMIT_KEY,
     }
     params = {k: good[v] for k, v in params_map.iteritems()}


### PR DESCRIPTION
The Jenkins bisection paramters have now been documented and fixed,
the "TREE" parameter has been renamed "KERNEL_TREE" so reflect that in
the request when triggering jobs.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>