### PR TITLE
Test documents: store raw json logs as well

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -486,4 +486,6 @@ def add_tests(job_data, lab_name, db_options, base_path=utils.BASE_PATH):
             if errors:
                 raise utils.errors.BackendError(errors)
 
+    store_lava_json(job_data, suite_data)
+
     return suite_doc_id


### PR DESCRIPTION
Since the boot and test documents have been splitted, the raw json would
only be recorded if calling on the /boot/ api.

Also record the json logs if it is a test callback.

Signed-off-by: Loys Ollivier <lollivier@baylibre.com>