### PR TITLE
Decode log lines in the LAVA callback to utf8

### DIFF
--- a/app/utils/lava_log_parser.py
+++ b/app/utils/lava_log_parser.py
@@ -87,11 +87,11 @@ def run(log, boot, txt, html):
         fmt = formats.get(level, None)
         if fmt:
             log_buffer.write(timestamp)
-            log_buffer.write(fmt.format(cgi.escape(msg)))
+            log_buffer.write(fmt.format(cgi.escape(msg.decode('utf-8'))))
             numbers[level] += 1
         elif level == "target":
             log_buffer.write(timestamp)
-            log_buffer.write(cgi.escape(msg))
+            log_buffer.write(cgi.escape(msg.decode('utf-8')))
             log_buffer.write("\n")
             txt.write(msg)
             txt.write("\n")


### PR DESCRIPTION
Recent python3 LAVA versions send the log files encoded with utf8. The API needs to decode these in order to use them correctly.

This also needs testing with an older LAVA lab as well