### PR TITLE
T7884 Add results fields to boot bisection documents

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -294,6 +294,9 @@ BISECT_GOOD_COMMIT_DATE = "good_commit_date"
 BISECT_BAD_COMMIT_DATE = "bad_commit_date"
 BISECT_GOOD_COMMIT_URL = "good_commit_url"
 BISECT_BAD_COMMIT_URL = "bad_commit_url"
+BISECT_FOUND_SUMMARY_KEY = "found_summary"
+BISECT_VERIFIED_KEY = "verified"
+BISECT_LOG_KEY = "log"
 
 # LAVA Callback keys
 LAVA_DEFINITION_KEY = "definition"

--- a/app/models/bisect.py
+++ b/app/models/bisect.py
@@ -38,6 +38,16 @@ class BisectDocument(modb.BaseDocument):
         self.job = None
         self.job_id = None
         self.type = None
+        self.found_summary = None
+        self.verified = None
+        self.log = None
+        self.git_branch = None
+        self.git_url = None
+        self.arch = None
+        self.defconfig = None
+        self.defconfig_full = None
+        self.compiler = None
+        self.build_id = None
 
     @property
     def collection(self):
@@ -103,7 +113,17 @@ class BisectDocument(modb.BaseDocument):
             models.JOB_ID_KEY: self.job_id,
             models.JOB_KEY: self.job,
             models.TYPE_KEY: self.type,
-            models.VERSION_KEY: self.version
+            models.VERSION_KEY: self.version,
+            models.BISECT_FOUND_SUMMARY_KEY: self.found_summary,
+            models.BISECT_VERIFIED_KEY: self.verified,
+            models.BISECT_LOG_KEY: self.log,
+            models.GIT_BRANCH_KEY: self.git_branch,
+            models.GIT_URL_KEY: self.git_url,
+            models.ARCHITECTURE_KEY: self.arch,
+            models.DEFCONFIG_FULL_KEY: self.defconfig_full,
+            models.DEFCONFIG_KEY: self.defconfig,
+            models.COMPILER_KEY: self.compiler,
+            models.BUILD_ID_KEY: self.build_id,
         }
 
         if self.id:
@@ -121,24 +141,21 @@ class BootBisectDocument(BisectDocument):
 
     def __init__(self, name):
         super(BootBisectDocument, self).__init__(name)
-
-        self.arch = None
+        self.lab_name = None
+        self.device_type = None
         self.board = None
         self.boot_id = None
-        self.build_id = None
-        self.defconfig = None
-        self.defconfig_full = None
         self.type = "boot"
 
     def to_dict(self):
-        boot_b_dict = super(BootBisectDocument, self).to_dict()
-        boot_b_dict[models.ARCHITECTURE_KEY] = self.arch
-        boot_b_dict[models.BOARD_KEY] = self.board
-        boot_b_dict[models.BOOT_ID_KEY] = self.boot_id
-        boot_b_dict[models.BUILD_ID_KEY] = self.build_id
-        boot_b_dict[models.DEFCONFIG_FULL_KEY] = self.defconfig_full
-        boot_b_dict[models.DEFCONFIG_KEY] = self.defconfig
-        return boot_b_dict
+        d = super(BootBisectDocument, self).to_dict()
+        d.update({
+            models.LAB_NAME_KEY: self.lab_name,
+            models.DEVICE_TYPE_KEY: self.device_type,
+            models.BOARD_KEY: self.board,
+            models.BOOT_ID_KEY: self.boot_id,
+        })
+        return d
 
 
 class DefconfigBisectDocument(BisectDocument):
@@ -146,20 +163,4 @@ class DefconfigBisectDocument(BisectDocument):
 
     def __init__(self, name):
         super(DefconfigBisectDocument, self).__init__(name)
-
-        self.arch = None
-        self.build_id = None
-        self.defconfig = None
-        self.defconfig_full = None
-        self.git_branch = None
         self.type = "build"
-
-    def to_dict(self):
-        def_b_dict = super(DefconfigBisectDocument, self).to_dict()
-        def_b_dict[models.ARCHITECTURE_KEY] = self.arch
-        def_b_dict[models.BUILD_ID_KEY] = self.build_id
-        def_b_dict[models.DEFCONFIG_FULL_KEY] = self.defconfig_full
-        def_b_dict[models.DEFCONFIG_KEY] = self.defconfig
-        def_b_dict[models.GIT_BRANCH_KEY] = self.git_branch
-
-        return def_b_dict

--- a/app/models/tests/test_bisect_model.py
+++ b/app/models/tests/test_bisect_model.py
@@ -60,7 +60,17 @@ class TestBisectModel(unittest.TestCase):
             "bad_commit_url": None,
             "version": None,
             "job_id": None,
-            "type": None
+            "type": None,
+            "found_summary": None,
+            "log": None,
+            "verified": None,
+            "arch": None,
+            "build_id": None,
+            "defconfig": None,
+            "defconfig_full": None,
+            "compiler": None,
+            "git_branch": None,
+            "git_url": None,
         }
         self.assertDictEqual(expected, bisect_doc.to_dict())
 
@@ -82,11 +92,22 @@ class TestBisectModel(unittest.TestCase):
             "bad_commit_url": None,
             "version": None,
             "job_id": None,
-            "type": None
+            "type": None,
+            "found_summary": None,
+            "log": None,
+            "verified": None,
+            "arch": None,
+            "build_id": None,
+            "defconfig": None,
+            "defconfig_full": None,
+            "compiler": None,
+            "git_branch": None,
+            "git_url": None,
         }
         self.assertDictEqual(expected, bisect_doc.to_dict())
 
     def test_bisect_boot_to_dict(self):
+        self.maxDiff = None
         bisect_doc = modbs.BootBisectDocument("foo")
         bisect_doc.id = "bar"
         bisect_doc.board = "baz"
@@ -94,6 +115,11 @@ class TestBisectModel(unittest.TestCase):
         bisect_doc.boot_id = "boot-id"
         bisect_doc.build_id = "build-id"
         bisect_doc.job_id = "job-id"
+        bisect_doc.git_url = "https://somewhere.com/blah.git"
+        bisect_doc.git_branch = "master"
+        bisect_doc.log = "https://storage.org/log.txt"
+        bisect_doc.device_type = "qemu"
+        bisect_doc.lab_name = "secret-lab"
 
         expected = {
             "_id": "bar",
@@ -113,9 +139,17 @@ class TestBisectModel(unittest.TestCase):
             "build_id": "build-id",
             "job_id": "job-id",
             "type": "boot",
+            "compiler": None,
+            "lab_name": "secret-lab",
             "arch": None,
+            "device_type": "qemu",
             "defconfig": None,
-            "defconfig_full": None
+            "defconfig_full": None,
+            "git_url": "https://somewhere.com/blah.git",
+            "git_branch": "master",
+            "log": "https://storage.org/log.txt",
+            "found_summary": None,
+            "verified": None,
         }
         self.assertDictEqual(expected, bisect_doc.to_dict())
 
@@ -131,6 +165,9 @@ class TestBisectModel(unittest.TestCase):
         bisect_doc.bad_commit = "2"
         bisect_doc.bad_commit_date = "now"
         bisect_doc.bad_commit_url = "url"
+        bisect_doc.found_summary = "1234abcd foo: bar"
+        bisect_doc.verified = "pass"
+        bisect_doc.log = "https://storage.org/log.txt"
 
         self.assertEqual(bisect_doc.id, "bar")
         self.assertEqual(bisect_doc.created_on, "now")
@@ -142,6 +179,9 @@ class TestBisectModel(unittest.TestCase):
         self.assertEqual(bisect_doc.bad_commit, "2")
         self.assertEqual(bisect_doc.bad_commit_date, "now")
         self.assertEqual(bisect_doc.bad_commit_url, "url")
+        self.assertEqual(bisect_doc.found_summary, "1234abcd foo: bar")
+        self.assertEqual(bisect_doc.verified, "pass")
+        self.assertEqual(bisect_doc.log, "https://storage.org/log.txt")
 
     def test_bisect_boot_properties(self):
         bisect_doc = modbs.BootBisectDocument("foo")
@@ -159,6 +199,8 @@ class TestBisectModel(unittest.TestCase):
         bisect_doc.job_id = "job-id"
         bisect_doc.defconfig_full = "defconfig-full"
         bisect_doc.arch = "arm"
+        bisect_doc.found_summary = "7890cdef foo: change bar into baz"
+        bisect_doc.git_url = "https://somewhere.com/blah.git"
 
         expected = {
             "_id": "bar",
@@ -177,9 +219,14 @@ class TestBisectModel(unittest.TestCase):
             "defconfig": "defconfig-name",
             "job_id": "job-id",
             "defconfig_full": "defconfig-full",
+            "compiler": None,
             "arch": "arm",
             "type": "build",
-            "git_branch": None
+            "git_branch": None,
+            "found_summary": "7890cdef foo: change bar into baz",
+            "git_url": "https://somewhere.com/blah.git",
+            "log": None,
+            "verified": None,
         }
 
         self.assertDictEqual(expected, bisect_doc.to_dict())


### PR DESCRIPTION
This is a first step to store the boot bisection results in the database.  It creates one bisection document for each regression found and automatically triggers a job for each of them too.  Further changes will then be needed to handle POST requests from the automated job to store the result into the existing documents.

See also one change required in the front-end: https://github.com/kernelci/kernelci-frontend/pull/28