### PR TITLE
T7884 Add handler for /bisect POST to save bisection results

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -789,7 +789,23 @@ BISECT_VALID_KEYS = {
         COLLECTION_KEY,
         COMPARE_TO_KEY,
         BUILD_ID_KEY
-    ]
+    ],
+    "POST": [
+        TYPE_KEY,
+        ARCHITECTURE_KEY,
+        JOB_KEY,
+        GIT_BRANCH_KEY,
+        DEFCONFIG_FULL_KEY,
+        LAB_NAME_KEY,
+        DEVICE_TYPE_KEY,
+        BISECT_GOOD_COMMIT_KEY,
+        BISECT_BAD_COMMIT_KEY,
+        BISECT_GOOD_SUMMARY_KEY,
+        BISECT_BAD_SUMMARY_KEY,
+        BISECT_FOUND_SUMMARY_KEY,
+        BISECT_LOG_KEY,
+        BISECT_CHECKS_KEY,
+    ],
 }
 
 TEST_SUITE_VALID_KEYS = {

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -294,8 +294,10 @@ BISECT_GOOD_COMMIT_DATE = "good_commit_date"
 BISECT_BAD_COMMIT_DATE = "bad_commit_date"
 BISECT_GOOD_COMMIT_URL = "good_commit_url"
 BISECT_BAD_COMMIT_URL = "bad_commit_url"
+BISECT_GOOD_SUMMARY_KEY = "good_summary"
+BISECT_BAD_SUMMARY_KEY = "bad_summary"
 BISECT_FOUND_SUMMARY_KEY = "found_summary"
-BISECT_VERIFIED_KEY = "verified"
+BISECT_CHECKS_KEY = "checks"
 BISECT_LOG_KEY = "log"
 
 # LAVA Callback keys

--- a/app/models/bisect.py
+++ b/app/models/bisect.py
@@ -38,8 +38,10 @@ class BisectDocument(modb.BaseDocument):
         self.job = None
         self.job_id = None
         self.type = None
+        self.good_summary = None
+        self.bad_summary = None
         self.found_summary = None
-        self.verified = None
+        self.checks = {}
         self.log = None
         self.git_branch = None
         self.git_url = None
@@ -114,8 +116,10 @@ class BisectDocument(modb.BaseDocument):
             models.JOB_KEY: self.job,
             models.TYPE_KEY: self.type,
             models.VERSION_KEY: self.version,
+            models.BISECT_GOOD_SUMMARY_KEY: self.good_summary,
+            models.BISECT_BAD_SUMMARY_KEY: self.bad_summary,
             models.BISECT_FOUND_SUMMARY_KEY: self.found_summary,
-            models.BISECT_VERIFIED_KEY: self.verified,
+            models.BISECT_CHECKS_KEY: self.checks,
             models.BISECT_LOG_KEY: self.log,
             models.GIT_BRANCH_KEY: self.git_branch,
             models.GIT_URL_KEY: self.git_url,

--- a/app/models/tests/test_bisect_model.py
+++ b/app/models/tests/test_bisect_model.py
@@ -55,15 +55,17 @@ class TestBisectModel(unittest.TestCase):
             "good_commit": None,
             "good_commit_date": None,
             "good_commit_url": None,
+            "good_summary": None,
             "bad_commit": None,
             "bad_commit_date": None,
             "bad_commit_url": None,
+            "bad_summary": None,
             "version": None,
             "job_id": None,
             "type": None,
             "found_summary": None,
             "log": None,
-            "verified": None,
+            "checks": {},
             "arch": None,
             "build_id": None,
             "defconfig": None,
@@ -87,15 +89,17 @@ class TestBisectModel(unittest.TestCase):
             "good_commit": None,
             "good_commit_date": None,
             "good_commit_url": None,
+            "good_summary": None,
             "bad_commit": None,
             "bad_commit_date": None,
             "bad_commit_url": None,
+            "bad_summary": None,
             "version": None,
             "job_id": None,
             "type": None,
             "found_summary": None,
             "log": None,
-            "verified": None,
+            "checks": {},
             "arch": None,
             "build_id": None,
             "defconfig": None,
@@ -107,7 +111,6 @@ class TestBisectModel(unittest.TestCase):
         self.assertDictEqual(expected, bisect_doc.to_dict())
 
     def test_bisect_boot_to_dict(self):
-        self.maxDiff = None
         bisect_doc = modbs.BootBisectDocument("foo")
         bisect_doc.id = "bar"
         bisect_doc.board = "baz"
@@ -131,9 +134,11 @@ class TestBisectModel(unittest.TestCase):
             "good_commit": None,
             "good_commit_date": None,
             "good_commit_url": None,
+            "good_summary": None,
             "bad_commit": None,
             "bad_commit_date": None,
             "bad_commit_url": None,
+            "bad_summary": None,
             "version": "1.0",
             "boot_id": "boot-id",
             "build_id": "build-id",
@@ -149,7 +154,7 @@ class TestBisectModel(unittest.TestCase):
             "git_branch": "master",
             "log": "https://storage.org/log.txt",
             "found_summary": None,
-            "verified": None,
+            "checks": {},
         }
         self.assertDictEqual(expected, bisect_doc.to_dict())
 
@@ -211,9 +216,11 @@ class TestBisectModel(unittest.TestCase):
             "good_commit": None,
             "good_commit_date": None,
             "good_commit_url": None,
+            "good_summary": None,
             "bad_commit": None,
             "bad_commit_date": None,
             "bad_commit_url": None,
+            "bad_summary": None,
             "version": "1.0",
             "build_id": "build-id",
             "defconfig": "defconfig-name",
@@ -226,7 +233,7 @@ class TestBisectModel(unittest.TestCase):
             "found_summary": "7890cdef foo: change bar into baz",
             "git_url": "https://somewhere.com/blah.git",
             "log": None,
-            "verified": None,
+            "checks": {},
         }
 
         self.assertDictEqual(expected, bisect_doc.to_dict())

--- a/app/taskqueue/tasks/bisect.py
+++ b/app/taskqueue/tasks/bisect.py
@@ -18,6 +18,17 @@ import utils.bisect.boot as bootb
 import utils.bisect.defconfig as defconfigb
 
 
+@taskc.app.task(name="import-boot-bisect")
+def import_boot_bisect(data):
+    """Just a wrapper around the real boot bisect import function.
+
+    :param data: Bisection results from the JSON data.
+    :type data: dictionary
+    :return Status code with result of the operation.
+    """
+    return bootb.update_results(data, taskc.app.conf.db_options)
+
+
 @taskc.app.task(name="boot-bisect", ignore_result=False)
 def boot_bisect(doc_id, db_options, fields=None):
     """Run a boot bisect operation on the passed boot document id.

--- a/app/utils/bisect/boot.py
+++ b/app/utils/bisect/boot.py
@@ -351,3 +351,34 @@ def create_boot_bisect(good, bad, db_options):
     doc.device_type = bad[models.DEVICE_TYPE_KEY]
     bcommon.save_bisect_doc(database, doc, bad_boot_id)
     return doc
+
+
+def update_results(data, db_options):
+    """Update boot bisection results
+
+    :param data: Meta-data of the boot bisection including results
+    :type data: dict
+    :param db_options: The options for the database connection.
+    :type db_options: dictionary
+    :return A numeric value with the result status.
+    """
+    database = utils.db.get_db_connection(db_options)
+    specs = {x: data[x] for x in [
+        models.TYPE_KEY,
+        models.ARCHITECTURE_KEY,
+        models.DEFCONFIG_FULL_KEY,
+        models.JOB_KEY,
+        models.GIT_BRANCH_KEY,
+        models.LAB_NAME_KEY,
+        models.DEVICE_TYPE_KEY,
+        models.BISECT_GOOD_COMMIT_KEY,
+        models.BISECT_BAD_COMMIT_KEY,
+    ]}
+    update = {k: data[k] for k in [
+        models.BISECT_GOOD_SUMMARY_KEY,
+        models.BISECT_BAD_SUMMARY_KEY,
+        models.BISECT_FOUND_SUMMARY_KEY,
+        models.BISECT_LOG_KEY,
+        models.BISECT_CHECKS_KEY,
+    ]}
+    return utils.db.update(database[models.BISECT_COLLECTION], specs, update)


### PR DESCRIPTION
Add a BisectHandler._post() method to handle POST requests and run a
task to update a BootBisectionDocument with the results.  This relies
on having a document previously created when triggering the bisection.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>