### PR TITLE
T9475 Add BisectDocument.kernel with kernel identifier

### DIFF
--- a/app/models/bisect.py
+++ b/app/models/bisect.py
@@ -43,6 +43,7 @@ class BisectDocument(modb.BaseDocument):
         self.found_summary = None
         self.checks = {}
         self.log = None
+        self.kernel = None
         self.git_branch = None
         self.git_url = None
         self.arch = None
@@ -121,6 +122,7 @@ class BisectDocument(modb.BaseDocument):
             models.BISECT_FOUND_SUMMARY_KEY: self.found_summary,
             models.BISECT_CHECKS_KEY: self.checks,
             models.BISECT_LOG_KEY: self.log,
+            models.KERNEL_KEY: self.kernel,
             models.GIT_BRANCH_KEY: self.git_branch,
             models.GIT_URL_KEY: self.git_url,
             models.ARCHITECTURE_KEY: self.arch,

--- a/app/models/tests/test_bisect_model.py
+++ b/app/models/tests/test_bisect_model.py
@@ -64,6 +64,7 @@ class TestBisectModel(unittest.TestCase):
             "job_id": None,
             "type": None,
             "found_summary": None,
+            "kernel": None,
             "log": None,
             "checks": {},
             "arch": None,
@@ -98,6 +99,7 @@ class TestBisectModel(unittest.TestCase):
             "job_id": None,
             "type": None,
             "found_summary": None,
+            "kernel": None,
             "log": None,
             "checks": {},
             "arch": None,
@@ -120,6 +122,7 @@ class TestBisectModel(unittest.TestCase):
         bisect_doc.job_id = "job-id"
         bisect_doc.git_url = "https://somewhere.com/blah.git"
         bisect_doc.git_branch = "master"
+        bisect_doc.kernel = "v123.456"
         bisect_doc.log = "https://storage.org/log.txt"
         bisect_doc.device_type = "qemu"
         bisect_doc.lab_name = "secret-lab"
@@ -152,6 +155,7 @@ class TestBisectModel(unittest.TestCase):
             "defconfig_full": None,
             "git_url": "https://somewhere.com/blah.git",
             "git_branch": "master",
+            "kernel": "v123.456",
             "log": "https://storage.org/log.txt",
             "found_summary": None,
             "checks": {},
@@ -172,6 +176,7 @@ class TestBisectModel(unittest.TestCase):
         bisect_doc.bad_commit_url = "url"
         bisect_doc.found_summary = "1234abcd foo: bar"
         bisect_doc.verified = "pass"
+        bisect_doc.kernel = "v456.789"
         bisect_doc.log = "https://storage.org/log.txt"
 
         self.assertEqual(bisect_doc.id, "bar")
@@ -186,6 +191,7 @@ class TestBisectModel(unittest.TestCase):
         self.assertEqual(bisect_doc.bad_commit_url, "url")
         self.assertEqual(bisect_doc.found_summary, "1234abcd foo: bar")
         self.assertEqual(bisect_doc.verified, "pass")
+        self.assertEqual(bisect_doc.kernel, "v456.789")
         self.assertEqual(bisect_doc.log, "https://storage.org/log.txt")
 
     def test_bisect_boot_properties(self):
@@ -205,6 +211,7 @@ class TestBisectModel(unittest.TestCase):
         bisect_doc.defconfig_full = "defconfig-full"
         bisect_doc.arch = "arm"
         bisect_doc.found_summary = "7890cdef foo: change bar into baz"
+        bisect_doc.kernel = "v4.56"
         bisect_doc.git_url = "https://somewhere.com/blah.git"
 
         expected = {
@@ -232,6 +239,7 @@ class TestBisectModel(unittest.TestCase):
             "git_branch": None,
             "found_summary": "7890cdef foo: change bar into baz",
             "git_url": "https://somewhere.com/blah.git",
+            "kernel": "v4.56",
             "log": None,
             "checks": {},
         }

--- a/app/utils/bisect/boot.py
+++ b/app/utils/bisect/boot.py
@@ -340,6 +340,7 @@ def create_boot_bisect(good, bad, db_options):
     doc.bad_commit = bad_commit
     doc.bad_commit_url = bad[models.GIT_URL_KEY]
     doc.bad_commit_date = bad[models.CREATED_KEY]
+    doc.kernel = bad[models.KERNEL_KEY]
     doc.git_branch = bad[models.GIT_BRANCH_KEY]
     doc.git_url = bad[models.GIT_URL_KEY]
     doc.arch = bad[models.ARCHITECTURE_KEY]
@@ -368,6 +369,7 @@ def update_results(data, db_options):
         models.ARCHITECTURE_KEY,
         models.DEFCONFIG_FULL_KEY,
         models.JOB_KEY,
+        models.KERNEL_KEY,
         models.GIT_BRANCH_KEY,
         models.LAB_NAME_KEY,
         models.DEVICE_TYPE_KEY,

--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -491,6 +491,7 @@ def _start_bisection(bisection, jopts):
         "TARGET": models.DEVICE_TYPE_KEY,
         "LAB": models.LAB_NAME_KEY,
         "KERNEL_TREE": models.JOB_KEY,
+        "KERNEL_NAME": models.KERNEL_KEY,
         "GOOD_COMMIT": models.BISECT_GOOD_COMMIT_KEY,
         "BAD_COMMIT": models.BISECT_BAD_COMMIT_KEY,
     }


### PR DESCRIPTION
Rather than relying on the output of "git describe" to consistently
track the kernel name, keep the string originally used.  This solves
issues with various versions of Git showing different default output
format for "git describe", and makes the logic more future-proof in
case kernel identifiers are not plain "git describe" outputs any more.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>