### PR TITLE
T9356 lava_log_parser: write logs as Unicode

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -11,6 +11,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import codecs
 import errno
 import models
 import os
@@ -254,7 +255,8 @@ def _add_boot_log(meta, job_log, base_path, name):
             if e.errno != errno.EEXIST:
                 raise e
 
-    with open(txt_path, "w") as txt, open(html_path, "w") as html:
+    with codecs.open(txt_path, "w", "utf-8") as txt, \
+         codecs.open(html_path, "w", "utf-8") as html:
         utils.lava_log_parser.run(log, meta, txt, html)
 
 

--- a/app/utils/lava_log_parser.py
+++ b/app/utils/lava_log_parser.py
@@ -75,7 +75,7 @@ def run(log, boot, txt, html):
     }
     numbers = {"warning": 0, "error": 0}
     start_ts = None
-    log_buffer = StringIO.StringIO()
+    log_buffer = []
 
     for line in log:
         iso_ts = dateutil.parser.parse(line["dt"])
@@ -84,15 +84,13 @@ def run(log, boot, txt, html):
 
         level, msg = (line.get(k) for k in ["lvl", "msg"])
 
+
         fmt = formats.get(level, None)
         if fmt:
-            log_buffer.write(timestamp)
-            log_buffer.write(fmt.format(cgi.escape(msg)))
+            log_buffer.append(timestamp + fmt.format(cgi.escape(msg)))
             numbers[level] += 1
         elif level == "target":
-            log_buffer.write(timestamp)
-            log_buffer.write(cgi.escape(msg))
-            log_buffer.write("\n")
+            log_buffer.append(timestamp + cgi.escape(msg) + "\n")
             txt.write(msg)
             txt.write("\n")
         elif level == "info" and msg.startswith("Start time: "):
@@ -110,7 +108,8 @@ def run(log, boot, txt, html):
     if start_ts:
         html.write("<li class=\"result\">{}</li>".format(start_ts))
     html.write("</ul><pre>\n")
-    html.write(log_buffer.getvalue())
+    for line in log_buffer:
+        html.write(line)
     html.write("</pre></body></html>\n")
 
 


### PR DESCRIPTION
Handle incoming Unicode strings by opening the log files in Unicode
mode and not converting log lines to ASCII.

With LAVA moving to Python 3 which uses Unicode for all the strings,
some characters were not compatible with ASCII any more, causing some
logs to fail to be parsed.  This fixes the issue and remains
compatible with older versions of LAVA running Python 2.7.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>