### PR TITLE
models: add missing KERNEL_KEY in bisect POST

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -793,6 +793,7 @@ BISECT_VALID_KEYS = {
         TYPE_KEY,
         ARCHITECTURE_KEY,
         JOB_KEY,
+        KERNEL_KEY,
         GIT_BRANCH_KEY,
         DEFCONFIG_FULL_KEY,
         LAB_NAME_KEY,


### PR DESCRIPTION
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>
Fixes: 3d208b2d390f ("Add BisectDocument.kernel with kernel identifier")