### PR TITLE
Fix error handling when no bisect document found for email report

### DIFF
--- a/app/taskqueue/tasks/report.py
+++ b/app/taskqueue/tasks/report.py
@@ -159,10 +159,13 @@ def send_bisect_report(report_data, email_opts, base_path=utils.BASE_PATH):
 
     db_options = taskc.app.conf.get("db_options", {})
 
-    txt_body, html_body, headers = \
-        utils.report.bisect.create_bisect_report(
-            report_data, email_opts["format"], db_options)
+    report_data = utils.report.bisect.create_bisect_report(
+        report_data, email_opts["format"], db_options)
 
+    if not report_data:
+        return status
+
+    txt_body, html_body, headers = report_data
     status, errors = utils.emails.send_email(
         email_opts["subject"], txt_body, html_body, email_opts,
         taskc.app.conf.mail_options, headers)

--- a/app/utils/report/bisect.py
+++ b/app/utils/report/bisect.py
@@ -24,6 +24,19 @@ import utils.report.common as rcommon
 
 def create_bisect_report(data, email_format, db_options,
                          base_path=utils.BASE_PATH):
+    """Create the bisection report email to be sent.
+
+    :param data: The meta-data for the bisection job.
+    :type data: dictionary
+    :param email_format: The email format to send.
+    :type email_format: list
+    :param db_options: The mongodb database connection parameters.
+    :type db_options: dict
+    :param base_path: Path to the top-level storage directory.
+    :type base_path: string
+    :return A tuple with the TXT email body, the HTML email body and the
+    headers as dictionary.  If an error occured, None.
+    """
     database = utils.db.get_db_connection(db_options)
 
     job, branch, kernel, lab, target = (data[k] for k in [
@@ -48,7 +61,7 @@ def create_bisect_report(data, email_format, db_options,
     doc = utils.db.find_one2(database[models.BISECT_COLLECTION], specs)
     if not doc:
         utils.LOG.warning("Failed to find bisection document")
-        return None, None, {}
+        return None
 
     headers = {
         rcommon.X_REPORT: rcommon.BISECT_REPORT_TYPE,


### PR DESCRIPTION
Bisection email reports need a bisect document from the database which
contains all the meta-data from the original regression and the
bisection results.  When that document can't be found, for example if
the bisection was hand-crafted rather than triggered by the
kernelci-backend, then propagate the error early and do not try to
send any email report.

Also update the docstring in utils.report.bisect.create_bisect_report().

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>