### PR TITLE
T9718 build.txt: fix Unicode handling errors

### DIFF
--- a/app/utils/report/templates/build.txt
+++ b/app/utils/report/templates/build.txt
@@ -46,19 +46,19 @@
 {%- if errors_summary.errors %}
 Errors summary:
 {% for err in errors_summary.errors %}
-    {{ "{:>3d}  {:s}".format(err[0], err[1]) -}}
+    {{ "%-3d  %s" % (err[0], err[1]) -}}
 {% endfor %}
 {%- endif %}{# end errors #}
 {% if errors_summary.warnings %}
 Warnings summary:
 {% for warn in errors_summary.warnings %}
-    {{ "{:>3d}  {:s}".format(warn[0], warn[1]) -}}
+    {{ "%-3d  %s" % (warn[0], warn[1]) -}}
 {% endfor %}
 {%- endif %}{# end warnings #}
 {% if errors_summary.mismatches %}
 Section mismatches summary:
 {% for mism in errors_summary.mismatches %}
-    {{ "{:>3d}  {:s}".format(mism[0], mism[1]) -}}
+    {{ "%-3d  %s" % (mism[0], mism[1]) -}}
 {% endfor %}
 {% endif %}{# end mismatches #}
 {%- endif %}{# and errors summary #}


### PR DESCRIPTION
The Jinja2 .format() filter automatically treats the template string
as ASCII unless it contained Unicode characters, on Python 2.7.  If
the values passed to this template are Unicode, then it raises a
UnicodeEncodeError as it can't convert Unicode to ASCII.

Use the % format in build.txt Jinja2 template to avoid this issue.
This would probably not be an issue on Python 3 which treats all
strings as Unicode.  The build.txt template was the only one to show
this problem.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>