### PR TITLE
[bugfix] templates/multiple_emails.txt: fix email_type

### DIFF
--- a/app/utils/report/templates/multiple_emails.txt
+++ b/app/utils/report/templates/multiple_emails.txt
@@ -24,9 +24,7 @@ Details
 {{ "{:-^80}".format("") }}
 
 Report type:
-{%- for e_type in email_type %}
-    * {{ e_type }}
-{%- endfor %}
+    * {{ email_type }}
 
 Email format:
 {%- for format in email_format %}


### PR DESCRIPTION
The template multiple_emails.txt was expecting for a list of strings
(report type) in the variable email_type, but this variable is
a single string with the type (build, boot, test).

Signed-off-by: Ana Guerrero Lopez <ana.guerrero@collabora.com>