### PR TITLE
add image.type to test_suite document

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -106,6 +106,7 @@ GIT_DESCRIBE_V_KEY = "git_describe_v"
 GIT_URL_KEY = "git_url"
 GTE_KEY = "gte"
 ID_KEY = "_id"
+IMAGE_TYPE_KEY = "image_type"
 INITRD_ADDR_KEY = "initrd_addr"
 INITRD_KEY = "initrd"
 IP_ADDRESS_KEY = "ip_address"
@@ -484,6 +485,7 @@ BOOT_VALID_KEYS = {
             GIT_DESCRIBE_KEY,
             GIT_URL_KEY,
             ID_KEY,
+            IMAGE_TYPE_KEY,
             INITRD_ADDR_KEY,
             INITRD_KEY,
             JOB_KEY,
@@ -1086,6 +1088,7 @@ DISTINCT_VALID_FIELDS = {
         DEFCONFIG_FULL_KEY,
         DEFCONFIG_KEY,
         GIT_BRANCH_KEY,
+        IMAGE_TYPE_KEY,
         JOB_ID_KEY,
         JOB_KEY,
         KERNEL_KEY,

--- a/app/models/test_suite.py
+++ b/app/models/test_suite.py
@@ -66,6 +66,7 @@ class TestSuiteDocument(modb.BaseDocument):
         self.git_commit = None
         self.git_describe = None
         self.git_url = None
+        self.image_type = None
         self.initrd_addr = None
         self.job = None
         self.job_id = None
@@ -173,6 +174,7 @@ class TestSuiteDocument(modb.BaseDocument):
             models.GIT_COMMIT_KEY: self.git_commit,
             models.GIT_DESCRIBE_KEY: self.git_describe,
             models.GIT_URL_KEY: self.git_url,
+            models.IMAGE_TYPE_KEY: self.image_type,
             models.INITRD_ADDR_KEY: self.initrd_addr,
             models.JOB_ID_KEY: self.job_id,
             models.JOB_KEY: self.job,

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -70,6 +70,7 @@ META_DATA_MAP_TEST = {
     models.KERNEL_IMAGE_KEY: "job.kernel_image",
     models.MACH_KEY: "platform.mach",
     models.VCS_COMMIT_KEY: "git.commit",
+    models.IMAGE_TYPE_KEY: "image.type",
 }
 
 META_DATA_MAP_BOOT = {

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -356,6 +356,7 @@ def _update_test_suite_doc_from_json(suite_doc, test_dict, errors):
     suite_doc.git_commit = test_dict.get(models.GIT_COMMIT_KEY, None)
     suite_doc.git_describe = test_dict.get(models.GIT_DESCRIBE_KEY, None)
     suite_doc.git_url = test_dict.get(models.GIT_URL_KEY, None)
+    suite_doc.image_type = test_dict.get(models.IMAGE_TYPE_KEY, None)
     suite_doc.initrd_addr = test_dict.get(models.INITRD_ADDR_KEY, None)
     suite_doc.job = test_dict.get(models.JOB_KEY, None)
     suite_doc.kernel = test_dict.get(models.KERNEL_KEY, None)


### PR DESCRIPTION
Parse image.type from the kernelCI metadata and save into the
test_suite document stored in the db.

All kernelCI jobs are setting this field to "kernel-ci" today, but we
could use this to distinguish different types of images (e.g. yocto,
etc.)

Signed-off-by: Kevin Hilman <khilman@baylibre.com>