### PR TITLE
Tests suite report mails update

### DIFF
--- a/app/handlers/send.py
+++ b/app/handlers/send.py
@@ -62,6 +62,7 @@ REPORT_TYPE_KEYS = {
         models.JOB_KEY,
         models.GIT_BRANCH_KEY,
         models.KERNEL_KEY,
+        models.PLANS_KEY,
     ],
 }
 
@@ -93,6 +94,10 @@ class SendHandler(hbase.BaseHandler):
         countdown = j_get(models.DELAY_KEY)
         if countdown is None:
             countdown = self.settings["senddelay"]
+
+        plans = j_get(models.PLANS_KEY)
+        if plans is None:
+            plans = []
 
         # Deprecated - ToDo: use report_type only in client code
         if j_get(models.SEND_BOOT_REPORT_KEY):
@@ -362,10 +367,11 @@ class SendHandler(hbase.BaseHandler):
         has_errors = False
         error_string = None
 
-        job, git_branch, kernel = (report_data[k] for k in [
+        job, git_branch, kernel, plans = (report_data[k] for k in [
             models.JOB_KEY,
             models.GIT_BRANCH_KEY,
             models.KERNEL_KEY,
+            models.PLANS_KEY
         ])
 
         if email_opts.get("to"):
@@ -374,6 +380,7 @@ class SendHandler(hbase.BaseHandler):
                     job,
                     git_branch,
                     kernel,
+                    plans,
                     report_data,
                     email_opts,
                 ],
@@ -383,8 +390,8 @@ class SendHandler(hbase.BaseHandler):
             has_errors = True
             error_string = "No email addresses provided to send test report to"
             self.log.error(
-                "No email addresses to send test report to for '%s-%s-%s'",
-                job, git_branch, kernel)
+                "No email addresses to send test report to for '%s-%s-%s-plans_%s'",
+                job, git_branch, kernel, "_".join(plans))
 
         return has_errors, error_string
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -200,6 +200,7 @@ REPORT_CC_KEY = "send_cc"
 REPORT_BCC_KEY = "send_bcc"
 DELAY_KEY = "delay"
 IN_REPLY_TO_KEY = "in_reply_to"
+PLANS_KEY = "plans"
 
 # Token special fields.
 ADMIN_KEY = "admin"
@@ -761,6 +762,7 @@ SEND_VALID_KEYS = {
             JOB_KEY,
             KERNEL_KEY,
             LAB_NAME_KEY,
+            PLANS_KEY,
             REPORT_TYPE_KEY,
             REPORT_BCC_KEY,
             REPORT_CC_KEY,

--- a/app/taskqueue/tasks/report.py
+++ b/app/taskqueue/tasks/report.py
@@ -179,7 +179,7 @@ def send_bisect_report(report_data, email_opts, base_path=utils.BASE_PATH):
 
 
 @taskc.app.task(name="send-test-report")
-def send_test_report(job, git_branch, kernel, report_data, email_opts):
+def send_test_report(job, git_branch, kernel, plans, report_data, email_opts):
     """Send the tests report email.
 
     :param job: The job name.
@@ -188,12 +188,17 @@ def send_test_report(job, git_branch, kernel, report_data, email_opts):
     :type git_branch: string
     :param kernel: The kernel name.
     :type kernel: string
+    :param plans: List of plans to include in the report.
+    :type plans: list
     :param report_data: The data necessary for generating a report.
     :type report_data: dict
     :param email_opts: Email options.
     :type email_opts: dict
     """
-    report_id = "-".join([job, git_branch, kernel])
+    if not plans:
+        report_id = "-".join([job, git_branch, kernel])
+    else:
+        report_id = "-".join([job, git_branch, kernel] + plans)
     utils.LOG.info(
         "Sending tests report email for '{}'".format(report_id))
 

--- a/app/utils/report/templates/test.html
+++ b/app/utils/report/templates/test.html
@@ -37,6 +37,7 @@ pre {
         <tr><td>URL</td><td>{{ git_url }}</td></tr>
         <tr><td>Kernel</td><td>{{ kernel }}</td></tr>
         <tr><td>Git Commit</td><td>{{ git_commit }}</td></tr>
+        <tr><td>Test plans</td><td>{{ plans_string }}</td></tr>
       </table>
     </p>
 

--- a/app/utils/report/templates/test.html
+++ b/app/utils/report/templates/test.html
@@ -44,6 +44,7 @@ pre {
     <p>
       {{ test_groups|length }} test groups results
       <table>
+        <col width="40">
         <col width="120">
         <col width="220">
         <col width="100">
@@ -52,14 +53,14 @@ pre {
         <col width="100">
         <col width="100">
         {% for t in test_groups|sort(attribute='name') -%}
-        <tr><th>{{ t.name|e }}</th><td>{{ t.board }}</td><td>{{ t.arch }}</td><td>{{ t.total_tests }} tests</td><td> {{ t.total["PASS"] }}  PASS</td><td>{{ t.total["FAIL"] }} FAIL </td><td>{{ t.total["SKIP"] }} SKIP</td></tr>
+        <tr><th>{{ loop.index }}</th><th>{{ t.name|e }}</th><td>{{ t.board }}</td><td>{{ t.arch }}</td><td>{{ t.total_tests }} tests</td><td> {{ t.total["PASS"] }}  PASS</td><td>{{ t.total["FAIL"] }} FAIL </td><td>{{ t.total["SKIP"] }} SKIP</td></tr>
         {%- endfor %}
       </table>
     </p>
 
     <h1>Tests</h1>
     {% for t in test_groups|sort(attribute='name') %}
-    <h2>{{ t.name|e }}</h2>
+    <h2>{{ loop.index }} | {{ t.name|e }}</h2>
     <table>
       <tr><td>Config</td><td>{{ t.defconfig_full }}</td></tr>
       <tr><td>Lab Name</td><td>{{ t.lab_name }}</td></tr>

--- a/app/utils/report/templates/test.html
+++ b/app/utils/report/templates/test.html
@@ -64,7 +64,6 @@ pre {
     <table>
       <tr><td>Config</td><td>{{ t.defconfig_full }}</td></tr>
       <tr><td>Lab Name</td><td>{{ t.lab_name }}</td></tr>
-      <tr><td>Board</td><td>{{ t.board }}</td></tr>
       <tr><td>Date</td><td>{{ t.created_on }}</td></tr>
     </table>
     {% if t.test_cases -%}

--- a/app/utils/report/templates/test.html
+++ b/app/utils/report/templates/test.html
@@ -50,8 +50,9 @@ pre {
         <col width="100">
         <col width="100">
         <col width="100">
+        <col width="100">
         {% for t in test_groups|sort(attribute='name') -%}
-        <tr><th>{{ t.name|e }}</th><td>{{ t.board }}</td><td>{{ t.total_tests }} tests</td><td> {{ t.total["PASS"] }}  PASS</td><td>{{ t.total["FAIL"] }} FAIL </td><td>{{ t.total["SKIP"] }} SKIP</td></tr>
+        <tr><th>{{ t.name|e }}</th><td>{{ t.board }}</td><td>{{ t.arch }}</td><td>{{ t.total_tests }} tests</td><td> {{ t.total["PASS"] }}  PASS</td><td>{{ t.total["FAIL"] }} FAIL </td><td>{{ t.total["SKIP"] }} SKIP</td></tr>
         {%- endfor %}
       </table>
     </p>

--- a/app/utils/report/templates/test.html
+++ b/app/utils/report/templates/test.html
@@ -65,6 +65,8 @@ pre {
       <tr><td>Config</td><td>{{ t.defconfig_full }}</td></tr>
       <tr><td>Lab Name</td><td>{{ t.lab_name }}</td></tr>
       <tr><td>Date</td><td>{{ t.created_on }}</td></tr>
+      <tr><td><a href="{{ storage_url }}/{{ t.job }}/{{ t.git_branch }}/{{ t.kernel }}/{{ t.arch }}/{{ t.defconfig_full }}/{{ t.lab_name }}/{{ t.boot_log }}">Link to TXT log</a></td><td></td></tr>
+      <tr><td><a href="{{ storage_url }}/{{ t.job }}/{{ t.git_branch }}/{{ t.kernel }}/{{ t.arch }}/{{ t.defconfig_full }}/{{ t.lab_name }}/{{ t.boot_log_html }}">Link to HTML log</a></td><td></td></tr>
     </table>
     {% if t.test_cases -%}
     <p>Test cases ({{ t.total_tests}}): </td><td><strong>{{ t.total["PASS"] }}</strong> PASS, <strong>{{ t.total["FAIL"] }}</strong> FAIL, <strong>{{ t.total["SKIP"] }}</strong> SKIP</p>

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -10,14 +10,14 @@ Summary
 -------
 {{ test_groups|length }} test groups results
 {% for t in test_groups|sort(attribute='name') %}
-{{ "%-10s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(t.name, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
+{{ "%-2s | %-10s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.name, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
 {%- endfor %}
 
 
 Tests
 -----
 {% for t in test_groups|sort(attribute='name') %}
-{{ t.name|e }} - {{ t.total_tests }} tests: {{ t.total["PASS"] }}  PASS, {{ t.total["FAIL"] }} FAIL, {{ t.total["SKIP"] }} SKIP
+{{ loop.index }} | {{ t.name|e }} - {{ t.total_tests }} tests: {{ t.total["PASS"] }}  PASS, {{ t.total["FAIL"] }} FAIL, {{ t.total["SKIP"] }} SKIP
 
   Config:      {{ t.defconfig_full }}
   Lab Name:    {{ t.lab_name }}

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -10,7 +10,7 @@ Summary
 -------
 {{ test_groups|length }} test groups results
 {% for t in test_groups|sort(attribute='name') %}
-{{ "%-10s | %-22s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(t.name, t.board, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
+{{ "%-10s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(t.name, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
 {%- endfor %}
 
 

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -22,6 +22,8 @@ Tests
   Config:      {{ t.defconfig_full }}
   Lab Name:    {{ t.lab_name }}
   Date:        {{ t.created_on }}
+  TXT log:     {{ storage_url }}/{{ t.job }}/{{ t.git_branch }}/{{ t.kernel }}/{{ t.arch }}/{{ t.defconfig_full }}/{{ t.lab_name }}/{{ t.boot_log }}
+  HTML log:    {{ storage_url }}/{{ t.job }}/{{ t.git_branch }}/{{ t.kernel }}/{{ t.arch }}/{{ t.defconfig_full }}/{{ t.lab_name }}/{{ t.boot_log_html }}
 {% if t.test_cases %}
   Test cases:
 {% for tc in t.test_cases %}

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -4,7 +4,7 @@ Test results for:
   Kernel:  {{ kernel }}
   URL:     {{ git_url }}
   Commit:  {{ git_commit }}
-
+  Test plans: {{ plans_string }}
 
 Summary
 -------

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -21,7 +21,6 @@ Tests
 
   Config:      {{ t.defconfig_full }}
   Lab Name:    {{ t.lab_name }}
-  Board:       {{ t.board }}
   Date:        {{ t.created_on }}
 {% if t.test_cases %}
   Test cases:

--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -26,6 +26,8 @@ TEST_REPORT_FIELDS = [
     models.BOARD_INSTANCE_KEY,
     models.BOARD_KEY,
     models.BOOT_ID_KEY,
+    models.BOOT_LOG_HTML_KEY,
+    models.BOOT_LOG_KEY,
     models.BUILD_ID_KEY,
     models.CREATED_KEY,
     models.DEFCONFIG_FULL_KEY,
@@ -154,6 +156,9 @@ def create_test_report(data, email_format, db_options,
         "git_url": git_url,
         "kernel": kernel,
         "git_commit": git_commit,
+        "boot_log": models.BOOT_LOG_KEY,
+        "boot_log_html": models.BOOT_LOG_HTML_KEY,
+        "storage_url": rcommon.DEFAULT_STORAGE_URL,
         "test_groups": top_groups,
     }
 

--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -148,6 +148,11 @@ def create_test_report(data, email_format, db_options,
 
     subject_str = "Test results for {}/{} - {}".format(job, branch, kernel)
 
+    if not plans:
+        plans_string = "All the results are included"
+    else:
+        plans_string = ", ".join(plans)
+
     git_url, git_commit = (top_groups[0][k] for k in [
         models.GIT_URL_KEY, models.GIT_COMMIT_KEY])
 
@@ -165,6 +170,7 @@ def create_test_report(data, email_format, db_options,
         "git_url": git_url,
         "kernel": kernel,
         "git_commit": git_commit,
+        "plans_string": plans_string,
         "boot_log": models.BOOT_LOG_KEY,
         "boot_log_html": models.BOOT_LOG_HTML_KEY,
         "storage_url": rcommon.DEFAULT_STORAGE_URL,


### PR DESCRIPTION
The changes in this PR can be sorted in two groups:

- improvements to the current test suite report mails, the most interesting one is adding the links to the lava logs
- a new feature to allow choosing the test reports we want to include in the email. This can be done adding the key plans when triggering the mails, e.g.:

```
curl -X POST -H "Authorization: $EMAIL_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"job": "'$TREE_NAME'", "kernel": "'$GIT_DESCRIBE'", "git_branch": "'$BRANCH'", "report_type": "test", "format": ["txt"], "plans": ["v4l2"], "send_to": ["'$EMAIL'"], "delay": 1}' ${API}/send
```

This would trigger a mail similar to this one:
https://gist.github.com/ana/91ad1ac1952c975a800096e3247f07df

The key `plans` is optional and if we omit it, we would get a mail with all the tests results like is one: https://gist.github.com/ana/f369cd2c834bc79818b3266a6949f275

I'm not including any example of an HTML report, but they have been updated as well.
