### PR TITLE
Allow to override DEFAULT_STORAGE_URL and DEFAULT_BASE_URL

### DIFF
--- a/app/utils/report/common.py
+++ b/app/utils/report/common.py
@@ -44,9 +44,9 @@ JOB_SEARCH_FIELDS = [
 ]
 
 DEFAULT_BASE_URL = u"https://kernelci.org"
-DEFAULT_BOOT_URL = u"https://kernelci.org/boot/all/job"
-BOOT_ID_URL = u"https://kernelci.org/boot/id/{_id:s}/"
-DEFAULT_BUILD_URL = u"https://kernelci.org/build"
+DEFAULT_BOOT_URL = DEFAULT_BASE_URL + u"/boot/all/job"
+BOOT_ID_URL = DEFAULT_BASE_URL + u"/boot/id/{_id:s}/"
+DEFAULT_BUILD_URL = DEFAULT_BASE_URL + u"/build"
 DEFAULT_STORAGE_URL = u"https://storage.kernelci.org"
 
 # Default colors for error and warning links.

--- a/app/utils/report/common.py
+++ b/app/utils/report/common.py
@@ -44,10 +44,23 @@ JOB_SEARCH_FIELDS = [
 ]
 
 DEFAULT_BASE_URL = u"https://kernelci.org"
+DEFAULT_STORAGE_URL = u"https://storage.kernelci.org"
+
+DEFAULT_CONFIG_FILE = "/etc/linaro/kernelci-backend.cfg"
+
+if os.path.isfile(DEFAULT_CONFIG_FILE):
+    with open(DEFAULT_CONFIG_FILE, 'r') as infile:
+        for line in infile:
+            if line.startswith("base_url"):
+                value = line.split("=")[1].strip()
+                DEFAULT_BASE_URL = value.replace("'","")
+            elif line.startswith("storage_url"):
+                value = line.split("=")[1].strip()
+                DEFAULT_STORAGE_URL = value.replace("'","")
+
 DEFAULT_BOOT_URL = DEFAULT_BASE_URL + u"/boot/all/job"
 BOOT_ID_URL = DEFAULT_BASE_URL + u"/boot/id/{_id:s}/"
 DEFAULT_BUILD_URL = DEFAULT_BASE_URL + u"/build"
-DEFAULT_STORAGE_URL = u"https://storage.kernelci.org"
 
 # Default colors for error and warning links.
 HTML_RED = u"#d9534f"


### PR DESCRIPTION
When using test instances, it's useful to have the mail reports showing the url from the local instance. This change allows to override these values in the file `/etc/linaro/kernelci-backend.cfg` using the values `base_url `and `storage_url`