### PR TITLE
T11785 missing test results in report

### DIFF
--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -179,7 +179,7 @@ def find_one3(
     return db[collection].find_one(spec_or_id, fields=fields, sort=sort)
 
 
-def find(collection, limit, skip, spec=None, fields=None, sort=None):
+def find(collection, limit=0, skip=0, spec=None, fields=None, sort=None):
     """Find documents in a collection with optional specified values.
 
     The `spec` argument is a dictionary of fields and values that should be
@@ -187,7 +187,7 @@ def find(collection, limit, skip, spec=None, fields=None, sort=None):
     returned. By default all documents in the collection will be returned.
 
     :param collection: The collection where to search.
-    :param limit: How many documents to return.
+    :param limit: How many documents to return, or 0 for not limit.
     :type int
     :param skip: How many document to skip from the result.
     :type int
@@ -204,7 +204,8 @@ def find(collection, limit, skip, spec=None, fields=None, sort=None):
         limit=limit, skip=skip, fields=fields, sort=sort, spec=spec)
 
 
-def find_and_count(collection, limit, skip, spec=None, fields=None, sort=None):
+def find_and_count(collection, limit=0, skip=0, spec=None, fields=None,
+                   sort=None):
     """Find all the documents in a collection, and return the total count.
 
     This will execute two operations: a `find` that will retrieve the documents
@@ -215,7 +216,7 @@ def find_and_count(collection, limit, skip, spec=None, fields=None, sort=None):
     number of documents in the collection.
 
     :param collection: The collection where to search.
-    :param limit: How many documents to return.
+    :param limit: How many documents to return, or 0 for no limit.
     :type int
     :param skip: How many document to skip from the result.
     :type int

--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -119,8 +119,6 @@ def create_test_report(data, email_format, db_options,
 
     test_group_docs = list(utils.db.find(
         database[models.TEST_GROUP_COLLECTION],
-        100,
-        0,
         spec=specs,
         fields=TEST_REPORT_FIELDS))
 


### PR DESCRIPTION
This is to fix the issue seen with v4l2 test report emails, where some platforms were missing (only Chromebook results were present, not the QEMU ones).  It turned out to be because the number of test groups returned by the mongo query was artificially limited, so some top-level groups were missing.  As there were more test cases when run on QEMU with the `vivid` driver, they were stored later in the database so were not at the top of the list, and as a result were truncated.