### PR TITLE
Require redis==2.10.6 to avoid incompatible upgrades with celery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Sphinx==1.4.9
 celery[redis]==3.1.25
 docutils==0.12
 futures==3.0.4
-hiredis
+hiredis==0.2.0
 jinja2
 netaddr==0.7.18
 pycares==1.0.0
@@ -11,7 +11,7 @@ python-jenkins==0.4.11
 python-dateutil
 pytz
 pyyaml==3.12
-redis
+redis==2.10.6
 scandir
 simplejson
 sphinx-bootstrap-theme


### PR DESCRIPTION
When running ansible, the version of redis jumped to 3.0.1, which is
not compatible with celery 3.1.25.  Pin down the version of redis to
avoid this issue.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>