### PR TITLE
utils/report: add the test plans list in the subject

### DIFF
--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -146,12 +146,12 @@ def create_test_report(data, email_format, db_options,
     for group in top_groups:
         _add_test_group_data(group, database)
 
-    subject_str = "Test results for {}/{} - {}".format(job, branch, kernel)
-
     if not plans:
         plans_string = "All the results are included"
+        subject_str = "Test results for {}/{} - {}".format(job, branch, kernel)
     else:
         plans_string = ", ".join(plans)
+        subject_str = "Test results ({}) for {}/{} - {}".format(plans_string, job, branch, kernel)
 
     git_url, git_commit = (top_groups[0][k] for k in [
         models.GIT_URL_KEY, models.GIT_COMMIT_KEY])


### PR DESCRIPTION
Put the list of test plans in the subject if we're not sending the results for all the test plans.

After this change, mails including all the test plans results for a  tree/branch/kernel will continue like until now, for example:
`Subject: Test results for mainline/master - v4.20-rc3-88-g663ac248cfde`

And mails including only a list of test plans, will have this list in the subject:
`Subject: Test results (simple, v4l2) for mainline/master - v4.20-rc3-88-g663ac248cfde`