### PR TITLE
Kill celery workers after 20 tasks, or over 60 seconds in a task

### DIFF
--- a/app/taskqueue/celeryconfig.py
+++ b/app/taskqueue/celeryconfig.py
@@ -38,3 +38,7 @@ CELERYD_TASK_LOG_FORMAT = (
     '[%(levelname)8s/%(processName)10s] '
     '[%(task_name)s(%(task_id)s)] %(message)s'
 )
+# process 20 tasks per child before it's replaced
+CELERYD_MAX_TASKS_PER_CHILD = 20
+# kill the process if the task takes longer than 60 seconds
+CELERYD_TASK_TIME_LIMIT = 90


### PR DESCRIPTION
On systems where celery workers have a habit of locking up, have the
processes refreshed more often (only let them process a certain number
of tasks before being replaced).

Rather than thrashing the system with a long running request, time it
out at 60 seconds and kill the worker.