### PR TITLE
Ignore lab name when looking for unique bisections

### DIFF
--- a/app/utils/bisect/boot.py
+++ b/app/utils/bisect/boot.py
@@ -314,7 +314,6 @@ def create_boot_bisect(good, bad, db_options):
     database = utils.db.get_db_connection(db_options)
     good_commit, bad_commit = (b[models.GIT_COMMIT_KEY] for b in (good, bad))
     spec = {x: bad[x] for x in [
-        models.LAB_NAME_KEY,
         models.DEVICE_TYPE_KEY,
         models.ARCHITECTURE_KEY,
         models.DEFCONFIG_FULL_KEY,
@@ -351,7 +350,7 @@ def create_boot_bisect(good, bad, db_options):
     doc.lab_name = bad[models.LAB_NAME_KEY]
     doc.device_type = bad[models.DEVICE_TYPE_KEY]
     bcommon.save_bisect_doc(database, doc, bad_boot_id)
-    return doc
+    return doc.to_dict()
 
 
 def update_results(data, db_options):

--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -219,6 +219,9 @@ def parse_regressions(lab_regressions, boot_data, db_options):
                             regr = create_regressions_data(boots, boot_data)
                             regr_board.append(regr)
 
+    # Remove duplicate entries - they are dictionaries so filter them by _id
+    bisections = {b['_id']: b for b in bisections}.values()
+
     if regressions_data:
         regressions["summary"] = {}
         regressions["summary"]["txt"] = ["Boot Regressions Detected:"]


### PR DESCRIPTION
While each bisection still needs to be associated with a specific lab,
oo not run the exact same bisection twice in more than one lab.  Also
ensure there aren't any duplicate bisections being triggered.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>