### PR TITLE
decrease verboseness when a test case is added or updated

### DIFF
--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -105,11 +105,11 @@ def save_or_update(doc, spec_map, collection, database, errors):
         doc_id = doc_get(models.ID_KEY)
         doc.id = doc_id
 
-        utils.LOG.info("Updating test document with id '%s'", doc_id)
+        utils.LOG.debug("Updating test document with id '%s'", doc_id)
         ret_val, _ = utils.db.save(database, doc)
     else:
         ret_val, doc_id = utils.db.save(database, doc, manipulate=True)
-        utils.LOG.info("New test document with id '%s'", doc_id)
+        utils.LOG.debug("New test document with id '%s'", doc_id)
 
     if ret_val == 500:
         err_msg = (

--- a/app/utils/tests_import.py
+++ b/app/utils/tests_import.py
@@ -424,7 +424,7 @@ def update_test_group_add_sub_group_id(
     ret_val = 200
     errors = {}
 
-    utils.LOG.info(
+    utils.LOG.debug(
         "Updating test group '{}' ({}) with sub-group ID {}".format(
             group_name, str(group_id), sub_group_id))
     database = utils.db.get_db_connection(db_options)
@@ -462,7 +462,7 @@ def update_test_group_add_test_case_id(
     ret_val = 200
     errors = {}
 
-    utils.LOG.info(
+    utils.LOG.debug(
         "Updating test group '%s' (%s) with test case ID",
         group_name, str(group_id))
     database = utils.db.get_db_connection(db_options)


### PR DESCRIPTION
Every time a test case is added or updated, the log at level INFO
outputs a line. This can be very noisy, specially with big tests.
Move these lines to DEBUG level, so they will be only show when
the backend has set the debug mode in /etc/linaro/kernelci-backend.cfg

Signed-off-by: Ana Guerrero Lopez <ana.guerrero@collabora.com>