### PR TITLE
Test regressions support 

### DIFF
--- a/app/handlers/callback.py
+++ b/app/handlers/callback.py
@@ -149,9 +149,16 @@ class LavaCallbackHandler(CallbackHandler):
         response.status_code = 202
         response.reason = "Request accepted and being processed"
 
-        if action in ["boot", "test"]:
+        if action == "boot":
             tasks = [
                 taskqueue.tasks.callback.lava_test.s(json_obj, lab_name),
+            ]
+            chain(tasks).apply_async(
+                link_error=taskqueue.tasks.error_handler.s())
+        elif action == "test":
+            tasks = [
+                taskqueue.tasks.callback.lava_test.s(json_obj, lab_name),
+                taskqueue.tasks.test.find_regression.s(),
             ]
             chain(tasks).apply_async(
                 link_error=taskqueue.tasks.error_handler.s())

--- a/app/handlers/dbindexes.py
+++ b/app/handlers/dbindexes.py
@@ -38,6 +38,7 @@ def ensure_indexes(database):
     _ensure_stats_indexes(database)
     _ensure_reports_indexes(database)
     _ensure_test_group_indexes(database)
+    _ensure_test_group_regressions_indexes(database)
     _ensure_test_case_indexes(database)
 
 
@@ -319,6 +320,34 @@ def _ensure_test_group_indexes(database):
         ],
         background=True
     )
+
+
+def _ensure_test_group_regressions_indexes(database):
+    """Ensure indexes exist on the test_group_regression collection.
+
+    :param database: The database connection.
+    """
+    collection = database[models.TEST_GROUP_REGRESSIONS_COLLECTION]
+    collection.ensure_index(
+        [
+            (models.CREATED_KEY, pymongo.DESCENDING),
+            (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
+            (models.JOB_KEY, pymongo.ASCENDING),
+            (models.KERNEL_KEY, pymongo.DESCENDING),
+            (models.NAME_KEY, pymongo.ASCENDING),
+        ],
+        background=True
+    )
+    collection.ensure_index(
+        [(models.JOB_ID_KEY, pymongo.DESCENDING)], background=True)
+
+    # The index collection.
+    collection = database[models.TEST_GROUP_REGRESSIONS_BY_TEST_GROUP_COLLECTION]
+    collection.ensure_index(
+        [(models.TEST_GROUP_REGRESSIONS_ID_KEY, pymongo.DESCENDING)],
+        background=True)
+    collection.ensure_index(
+        [(models.CREATED_KEY, pymongo.DESCENDING)], background=True)
 
 
 def _ensure_test_case_indexes(database):

--- a/app/handlers/test_group_regressions.py
+++ b/app/handlers/test_group_regressions.py
@@ -1,0 +1,69 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""The RequestHandler for /test[/<id>]/regressions/ URLs."""
+
+import bson
+
+import handlers.base as hbase
+import handlers.response as hresponse
+import models
+import utils.db
+
+from utils.kci_test.regressions import (
+    create_regressions_key,
+    get_regressions_by_key
+)
+
+# TODO: code for handling /test[/<id>]/regressions/ URLs.
+#  class TestGroupRegressionsHandler(hbase.BaseHandler):
+#        """Handle test group regressions request."""
+
+
+def find_regressions(doc_id, database):
+    """Look for the regressions of a test group report.
+
+    :param doc_id: The id of the test group to look for regressions.
+    :type doc_id: ObjectId
+    :return HandlerResponse A HandlerResponse object.
+    """
+    response = hresponse.HandlerResponse()
+    # First make sure we have a valid test_group_id value.
+    test_group_doc = utils.db.find_one2(
+        database[models.TEST_GROUP_COLLECTION], doc_id)
+
+    if test_group_doc:
+        regr_idx_doc = utils.db.find_one2(
+            database[models.TEST_GROUP_REGRESSIONS_BY_TEST_GROUP_COLLECTION],
+            {models.TEST_GROUP_ID_KEY: doc_id})
+
+        if regr_idx_doc:
+            spec = {
+                models.ID_KEY:
+                    regr_idx_doc[models.TEST_GROUP_REGRESSIONS_ID_KEY]
+            }
+
+            result = utils.db.find_one2(
+                database[models.TEST_GROUP_REGRESSIONS_COLLECTION],
+                spec, fields=[models.REGRESSIONS_KEY])
+
+            if result:
+                response.result = get_regressions_by_key(
+                    create_regressions_key(test_group_doc),
+                    result[models.REGRESSIONS_KEY])
+                response.count = len(response.result)
+    else:
+        response.status_code = 404
+        response.reason = "Resource '{:s}' not found".format(str(doc_id))
+
+    return response

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -169,6 +169,7 @@ TEST_JOB_PATH_KEY = "test_job_path"
 TEST_JOB_URL_KEY = "test_job_url"
 TEST_GROUP_ID_KEY = "test_group_id"
 TEST_GROUP_NAME_KEY = "test_group_name"
+TEST_GROUP_REGRESSIONS_ID_KEY = "test_group_regressions_id"
 TEXT_OFFSET_KEY = "text_offset"
 TIME_KEY = "time"
 TIME_RANGE_KEY = "time_range"
@@ -260,6 +261,9 @@ LAB_COLLECTION = "lab"
 REPORT_COLLECTION = "report"
 UPLOAD_COLLECTION = "upload"
 TEST_GROUP_COLLECTION = "test_group"
+TEST_GROUP_REGRESSIONS_BY_TEST_GROUP_COLLECTION = \
+                                  "test_group_regressions_by_test_group_id"
+TEST_GROUP_REGRESSIONS_COLLECTION = "test_group_regressions"
 TEST_CASE_COLLECTION = "test_case"
 ERROR_LOGS_COLLECTION = "error_logs"
 ERRORS_SUMMARY_COLLECTION = "errors_summary"
@@ -965,6 +969,7 @@ BOOT_REGRESSIONS_VALID_KEYS = {
         KERNEL_KEY
     ]
 }
+
 
 # Used by the DistinctHandler to handle query arguments on the various
 # supported resources.

--- a/app/taskqueue/tasks/test.py
+++ b/app/taskqueue/tasks/test.py
@@ -19,6 +19,7 @@ import utils
 import utils.db
 import utils.errors
 import utils.tests_import as tests_import
+import utils.kci_test.regressions
 
 ADD_ERR = utils.errors.add_error
 
@@ -113,3 +114,21 @@ def import_test_cases_from_test_group(
 
     # TODO: handle errors
     return ret_val
+
+
+@taskc.app.task(name="test-group-regressions")
+def find_regression(test_group_doc_ids):
+    """Trigger the find regression function.
+
+    This is a wrapper around the real function to provide a Celery task.
+    This function is concatenated to the
+    `taskqueue.tasks.callback.lava_test` one, and the results of the
+    previous execution are injected here.
+
+    :param test_group_doc_ids: List of test group document object id.
+    :return ObjectId The test group object id.
+    """
+
+    for test_group_doc_id in test_group_doc_ids:
+        utils.kci_test.regressions.find(test_group_doc_id,
+                                        taskc.app.conf.db_options)

--- a/app/utils/kci_test/regressions.py
+++ b/app/utils/kci_test/regressions.py
@@ -1,0 +1,485 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Logic to find regressions in test groups reports."""
+
+import bson
+import redis
+
+import models
+import utils
+import utils.database.redisdb as redisdb
+import utils.db
+
+# How the key to access the regressions data structure is formatted.
+# Done in this way so that we can use mongodb dot notation to access embedded
+# documents.
+REGRESSION_FMT = "{lab:s}.{arch:s}.{board:s}.{instance:s}.{defconfig:s}.{compiler:s}"
+# The real data structure is accessed with the name of the key followed by
+# the rest of the embedded document key.
+REGRESSION_DOT_FMT = "{name_key:s}.{document_key:s}"
+# Lock key format for the Redis lock.
+LOCK_KEY_FMT = "test-group-regressions-{job:s}-{branch:s}-{kernel:s}-{name:s}"
+
+
+def sanitize_key(key):
+    """Remove and replace invalid characters from a key.
+
+    MongoDB's document keys must not contain some special characters.
+
+    :param key: The key to sanitize.
+    :type key: str
+    :return str The sanitized key.
+    """
+    sanitized = key
+    if key:
+        sanitized = key.replace(" ", "").replace(".", ":")
+
+    return sanitized
+
+
+def create_regressions_key(test_group_doc):
+    """Generate the regressions key for this test group report.
+
+    :param test_group_doc: The test group report document.
+    :type test_group_doc: dict
+    :return str The test group regression key.
+    """
+    b_get = test_group_doc.get
+
+    arch = b_get(models.ARCHITECTURE_KEY)
+    b_instance = \
+        sanitize_key(str(b_get(models.BOARD_INSTANCE_KEY)).lower())
+    board = sanitize_key(b_get(models.BOARD_KEY))
+    compiler = sanitize_key(str(b_get(models.COMPILER_VERSION_EXT_KEY)))
+    defconfig = sanitize_key(b_get(models.DEFCONFIG_FULL_KEY))
+    lab = b_get(models.LAB_NAME_KEY)
+
+    return REGRESSION_FMT.format(lab=lab,
+                                 arch=arch,
+                                 board=board,
+                                 instance=b_instance,
+                                 defconfig=defconfig,
+                                 compiler=compiler)
+
+
+def get_regressions_by_key(key, regressions):
+    """From a formatted key, get the actual regressions list.
+
+    :param key: The key we need to look up.
+    :type key: str
+    :param regressions: The regressions data structure.
+    :type regressions: dict
+    :return list The regressions for the passed key.
+    """
+    k = key.split(".")
+    regr = []
+    try:
+        regr = regressions[k[0]][k[1]][k[2]][k[3]][k[4]][k[5]]
+    except (IndexError, KeyError):
+        utils.LOG.error("Error retrieving regressions with key: %s", key)
+
+    return regr
+
+
+def gen_regression_keys(regressions):
+    """Go through the regression data structure and yield the "keys".
+
+    The regression data structure is a dictionary with nested dictionaries.
+
+    :param regressions: The data structure that contains the regressions.
+    :type regressions: dict
+    :return str The regression key.
+    """
+    for lab in regressions.viewkeys():
+        lab_d = regressions[lab]
+
+        for arch in lab_d.viewkeys():
+            arch_d = lab_d[arch]
+
+            for board in arch_d.viewkeys():
+                board_d = arch_d[board]
+
+                for b_instance in board_d.viewkeys():
+                    instance_d = board_d[b_instance]
+
+                    for defconfig in instance_d.viewkeys():
+                        defconfig_d = instance_d[defconfig]
+
+                        for compiler in defconfig_d.viewkeys():
+                            yield REGRESSION_FMT.format(lab=lab,
+                                                        arch=arch,
+                                                        board=board,
+                                                        instance=b_instance,
+                                                        defconfig=defconfig,
+                                                        compiler=compiler)
+
+
+def check_prev_regression(last_test_group, prev_test_group, db_options):
+    """Check if we have a previous regression document.
+
+    Make sure that the test group we are looking for already has a key in a
+    regression document.
+
+    It will return a 2-tuple:
+    - (None, None) if nothing is found;
+    - (regr_doc_id, None) if we already have a regression document, but the
+      test group report is not tracked in there;
+    - (regr_doc_id, regr_list) if we have a regressions document and the test
+      group report is already tracked.
+
+    :param last_test_group: The test group we are looking at.
+    :type last_test_group: dict
+    :param prev_test_group: The previous test group report.
+    :type prev_test_group: dict
+    :param db_options: The database connection parameters.
+    :type db_options: dict
+    :return A 2-tuple: The ID of the regression document, and the list of
+    all previous regressions.
+    """
+    ret_val = (None, None)
+    p_get = prev_test_group.get
+
+    spec = {
+        models.GIT_BRANCH_KEY: p_get(models.GIT_BRANCH_KEY),
+        models.JOB_KEY: p_get(models.JOB_KEY),
+        models.KERNEL_KEY: p_get(models.KERNEL_KEY),
+        models.NAME_KEY: p_get(models.NAME_KEY)
+    }
+    if prev_test_group[models.JOB_ID_KEY]:
+        spec[models.JOB_ID_KEY] = p_get(models.JOB_ID_KEY)
+
+    prev_regr_doc = utils.db.find_one3(
+        models.TEST_GROUP_REGRESSIONS_COLLECTION, spec, db_options=db_options)
+
+    if prev_regr_doc:
+        prev_regr = prev_regr_doc[models.REGRESSIONS_KEY]
+
+        test_group_regr_key = create_regressions_key(last_test_group)
+        if test_group_regr_key in gen_regression_keys(prev_regr):
+            ret_val = (prev_regr_doc[models.ID_KEY], prev_regr)
+        else:
+            ret_val = (prev_regr_doc[models.ID_KEY], None)
+
+    return ret_val
+
+
+# pylint: disable=too-many-locals
+def track_regression(test_group_doc, pass_doc, old_regr, db_options):
+    """Track the regression for the provided test group report.
+
+    :param test_group_doc: The test group document where we have a regression.
+    :type test_group_doc: dict
+    :param pass_doc: The previous test group document, when we start tracking a
+    regression.
+    :type pass_doc: dict
+    :param old_regr: The previous regressions document.
+    :type old_regr: 2-tuple
+    :param db_options: The database connection parameters.
+    :type db_options: dict
+    :return tuple The status code (200, 201, 500); and the regression
+    document id.
+    """
+    ret_val = 201
+    doc_id = None
+
+    regr_key = create_regressions_key(test_group_doc)
+
+    b_get = test_group_doc.get
+    test_group_id = b_get(models.ID_KEY)
+    arch = b_get(models.ARCHITECTURE_KEY)
+    b_instance = sanitize_key(str(b_get(models.BOARD_INSTANCE_KEY)).lower())
+    board = sanitize_key(b_get(models.BOARD_KEY))
+    compiler = sanitize_key(str(b_get(models.COMPILER_VERSION_EXT_KEY)))
+    defconfig = sanitize_key(b_get(models.DEFCONFIG_FULL_KEY))
+    job = b_get(models.JOB_KEY)
+    job_id = b_get(models.JOB_ID_KEY)
+    kernel = b_get(models.KERNEL_KEY)
+    lab = b_get(models.LAB_NAME_KEY)
+    created_on = b_get(models.CREATED_KEY)
+    branch = b_get(models.GIT_BRANCH_KEY)
+    name = b_get(models.NAME_KEY)
+
+    # We might be importing test group in parallel through multi-processes.
+    # Keep a lock here when looking for the previous regressions or we might
+    # end up with multiple test group regression creations.
+    redis_conn = redisdb.get_db_connection(db_options)
+    lock_key = LOCK_KEY_FMT.format(job=job,
+                                   branch=branch,
+                                   kernel=kernel,
+                                   name=name)
+
+    with redis.lock.Lock(redis_conn, lock_key, timeout=5):
+        # Do we have "old" regressions?
+        regr_docs = []
+        if all([old_regr, old_regr[0]]):
+            regr_docs = get_regressions_by_key(
+                regr_key, old_regr[1])
+
+        if pass_doc:
+            regr_docs.append(pass_doc)
+
+        # Append the actual fail test group report to the list.
+        regr_docs.append(test_group_doc)
+
+        # Do we have already a regression registered for this job_id,
+        # job, kernel?
+        prev_reg_doc = check_prev_regression(test_group_doc,
+                                             test_group_doc,
+                                             db_options)
+        if prev_reg_doc[0]:
+            doc_id = prev_reg_doc[0]
+
+            regr_data_key = \
+                REGRESSION_DOT_FMT.format(name_key=models.REGRESSIONS_KEY,
+                                          document_key=regr_key)
+
+            if prev_reg_doc[1]:
+                # If we also have the same key in the document, append the
+                # new test group report.
+                document = {"$addToSet": {regr_data_key: test_group_doc}}
+            else:
+                # Otherwise just set the new key.
+                document = {"$set": {regr_data_key: regr_docs}}
+
+            ret_val = utils.db.update3(
+                models.TEST_GROUP_REGRESSIONS_COLLECTION,
+                {models.ID_KEY: prev_reg_doc[0]},
+                document,
+                db_options=db_options
+            )
+        else:
+            regression_doc = {
+                models.CREATED_KEY: created_on,
+                models.GIT_BRANCH_KEY: branch,
+                models.JOB_ID_KEY: job_id,
+                models.JOB_KEY: job,
+                models.KERNEL_KEY: kernel,
+                models.NAME_KEY: name
+            }
+
+            # The regression data structure.
+            # A dictionary with nested keys, whose keys in nested order are:
+            # lab name
+            # architecture type
+            # board name
+            # board instance or the string "none"
+            # defconfig full string
+            # compiler string (just compiler + version)
+            # The regressions are stored in a list as the value of the
+            # "compiler" key.
+            regression_doc[models.REGRESSIONS_KEY] = {
+                lab: {
+                    arch: {
+                        board: {
+                            b_instance: {
+                                defconfig: {
+                                    compiler: regr_docs
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            ret_val, doc_id = \
+                utils.db.save3(
+                    models.TEST_GROUP_REGRESSIONS_COLLECTION, regression_doc,
+                    db_options=db_options)
+
+        # Save the regressions id and test group id in an index collection.
+        if all([any([ret_val == 201, ret_val == 200]), doc_id]):
+            utils.db.save3(
+                models.TEST_GROUP_REGRESSIONS_BY_TEST_GROUP_COLLECTION,
+                {
+                    models.TEST_GROUP_ID_KEY: test_group_id,
+                    models.TEST_GROUP_REGRESSIONS_ID_KEY: doc_id,
+                    models.CREATED_KEY: created_on
+                },
+                db_options=db_options
+            )
+
+    return ret_val, doc_id
+
+
+def check_and_track(test_group_doc, db_options):
+    """Check previous test group report and start tracking regressions
+    for that group report. This function won't take care of the sub_groups
+    only of the top group.
+
+    :param test_group_doc: The test group document we are working on.
+    :type test_group_doc: dict
+    :param conn: The database connection.
+    :param db_options: The database connection parameters.
+    :type db_options: dict
+    :return tuple The return value; and the regression document id.
+    """
+    ret_val = None
+    doc_id = None
+
+    b_get = test_group_doc.get
+    # Look for an older and as much similar as possible test group report.
+    # In case the test group report we are analyzing is FAIL and the old one
+    # is PASS, it's a new regression that we need to track.
+    spec = {
+        models.ARCHITECTURE_KEY: b_get(models.ARCHITECTURE_KEY),
+        models.BOARD_KEY: b_get(models.BOARD_KEY),
+        models.COMPILER_VERSION_EXT_KEY:
+            b_get(models.COMPILER_VERSION_EXT_KEY),
+        models.CREATED_KEY: {"$lt": b_get(models.CREATED_KEY)},
+        models.DEFCONFIG_FULL_KEY: b_get(models.DEFCONFIG_FULL_KEY),
+        models.DEFCONFIG_KEY: b_get(models.DEFCONFIG_KEY),
+        models.GIT_BRANCH_KEY: b_get(models.GIT_BRANCH_KEY),
+        models.JOB_KEY: b_get(models.JOB_KEY),
+        models.LAB_NAME_KEY: b_get(models.LAB_NAME_KEY),
+        models.NAME_KEY: b_get(models.NAME_KEY),
+    }
+
+    old_doc = utils.db.find_one3(
+        models.TEST_GROUP_COLLECTION, spec, sort=[(models.CREATED_KEY, -1)])
+
+    if old_doc:
+        database = utils.db.get_db_connection(db_options)
+        _add_test_group_data(old_doc, database)
+
+        # If previous test failed this is a number higher than 0
+        if old_doc.get('total').get('FAIL') != 0:
+            # "Old" regression case, we might have to keep track of it.
+            utils.LOG.info("Previous test group report failed,"
+                           "checking previous regressions")
+
+            # Check if we have old regressions first.
+            # If not, we don't track it since it's the first time we
+            # know about it.
+            prev_reg = check_prev_regression(test_group_doc,
+                                             old_doc,
+                                             db_options)
+
+            if all([prev_reg[0], prev_reg[1]]):
+                utils.LOG.info("Found previous regressions, keep tracking")
+                ret_val, doc_id = track_regression(
+                    test_group_doc, None, prev_reg, db_options)
+            else:
+                utils.LOG.info("No previous regressions found, not tracking")
+        # Previous test didn't fail, this is a NEW regression
+        else:
+            # New regression case.
+            utils.LOG.info("Previous test group report passed, start tracking")
+            ret_val, doc_id = track_regression(
+                test_group_doc, old_doc, (None, None), db_options)
+    else:
+        utils.LOG.info("No previous test group report found, not tracking")
+
+    return ret_val, doc_id
+
+
+def _add_test_group_data(group, database):
+    """Replace the test_case and subgroups with the full information.
+    about the test cases and test groups respectively
+
+    :param group: The test group document we are working on.
+    :type group: dict
+    :param database: The database connection.
+    """
+    test_cases = []
+    for test_case_id in group[models.TEST_CASES_KEY]:
+        test_case = utils.db.find_one2(
+           database[models.TEST_CASE_COLLECTION],
+           {"_id": test_case_id})
+        test_cases.append(test_case)
+
+    sub_groups = []
+    for sub_group_id in group[models.SUB_GROUPS_KEY]:
+        sub_group = utils.db.find_one2(
+            database[models.TEST_GROUP_COLLECTION],
+            {"_id": sub_group_id})
+        _add_test_group_data(sub_group, database)
+        sub_groups.append(sub_group)
+
+    total = {status: 0 for status in ["PASS", "FAIL", "SKIP"]}
+
+    for test_case in test_cases:
+        total[test_case["status"]] += 1
+
+    for sub_group_total in (sg["total"] for sg in sub_groups):
+        for status, count in sub_group_total.iteritems():
+            total[status] += count
+
+    group.update({
+        "test_cases": test_cases,
+        "sub_groups": sub_groups,
+        "total_tests": sum(total.values()),
+        "total": total,
+    })
+
+
+def find(test_group_id, db_options):
+    """Find the regression starting from a single test group report.
+
+    :param test_group_id: The id of the test group document.
+                          Must be a valid ObjectId.
+    :type test_group_id: str, ObjectId
+    :param db_options: The database connection parameters.
+    :type db_options: dict
+    :return tuple The return value that can be 200, 201 or 500; the Id of the
+    regression document or None.
+    """
+    results = (None, None)
+
+    utils.LOG.info("Searching test group regressions for '%s'",
+                   str(test_group_id))
+
+    if not isinstance(test_group_id, bson.objectid.ObjectId):
+        try:
+            test_group_id = bson.objectid.ObjectId(test_group_id)
+        except bson.errors.InvalidId:
+            test_group_id = None
+            utils.LOG.info("Error converting test group id '%s'",
+                           str(test_group_id))
+
+    test_group_doc = utils.db.find_one3(
+        models.TEST_GROUP_COLLECTION, test_group_id, db_options=db_options)
+
+    if test_group_doc:
+        database = utils.db.get_db_connection(db_options)
+        _add_test_group_data(test_group_doc, database)
+        test_group_doc_failed = test_group_doc.get('total').get('FAIL')
+
+    if test_group_doc and test_group_doc_failed > 0:
+        # First check the top group
+        regressions_id = utils.db.find_one3(
+            models.TEST_GROUP_REGRESSIONS_BY_TEST_GROUP_COLLECTION,
+            {models.TEST_GROUP_ID_KEY: test_group_id},
+            db_options=db_options)
+
+        if regressions_id:
+            utils.LOG.info("Test regressions regressions are already "
+                           "tracked for {}".format(test_group_id))
+        else:
+            results = check_and_track(test_group_doc, db_options)
+
+            # Then we check the sub_groups, if any
+            sub_groups = test_group_doc["sub_groups"]
+            if sub_groups:
+                for sg in sub_groups:
+                    utils.LOG.info("Checking sub group: {}".format(sg['name']))
+                    if sg.get('total').get('FAIL') > 0:
+                        # Check if it's already tracked
+                        results = check_and_track(sg, db_options)
+                    else:
+                        utils.LOG.info("Nothing to track for sub group: "
+                                       "{}".format(sg['name']))
+    else:
+        utils.LOG.info("No test group doc or not failed test group report")
+
+    return results

--- a/app/utils/kci_test/tests/__init__.py
+++ b/app/utils/kci_test/tests/__init__.py
@@ -1,1 +1,0 @@
-# TODO write python unit tests

--- a/app/utils/kci_test/tests/test_group_regressions.py
+++ b/app/utils/kci_test/tests/test_group_regressions.py
@@ -1,0 +1,167 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import mock
+import mongomock
+import random
+import string
+import unittest
+
+import utils.kci_test.regressions as ktest_regressions
+
+
+class TestGroupRegressions(unittest.TestCase):
+
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+        self.db = mongomock.Database(mongomock.Connection(), "kernel-ci")
+
+        self._id = "".join(
+            [random.choice(string.digits) for x in xrange(24)])
+
+        self.pass_test = {
+            "name": "name",
+            "job": "job",
+            "kernel": "kernel",
+            "arch": "arm64",
+            "defconfig_full": "defconfig-full",
+            "defconfig": "defconfig",
+            "lab_name": "lab-foo",
+            "board": "arm64-board",
+            "created_on": "2018-11-29",
+            "test_cases": [],
+            "sub_groups": [],
+        }
+
+        self.fail_test = {
+            "name": "name",
+            "job": "job",
+            "kernel": "kernel1",
+            "arch": "arm64",
+            "defconfig_full": "defconfig-full",
+            "defconfig": "defconfig",
+            "lab_name": "lab-foo",
+            "board": "arm64-board",
+            "created_on": "2018-11-30",
+            "test_cases": [],
+            "sub_groups": [],
+        }
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
+
+    def test_get_regressions_by_key_wrong_index(self):
+        key = "a.b.c.d"
+        regressions = {
+            "a": {
+                "b": {
+                    "c": {
+                        "d": {
+                            "e": {
+                                "f": ["foo"]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        regr = ktest_regressions.get_regressions_by_key(key, regressions)
+        self.assertListEqual([], regr)
+
+    def test_get_regressions_by_key_wrong_key(self):
+        key = "a.b.c.e.h.j"
+        regressions = {
+            "a": {
+                "b": {
+                    "c": {
+                        "d": {
+                            "e": {
+                                "f": ["foo"]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        regr = ktest_regressions.get_regressions_by_key(key, regressions)
+        self.assertListEqual([], regr)
+
+    def test_get_regressions_by_key(self):
+        key = "a.b.c.d.e.f"
+        regressions = {
+            "a": {
+                "b": {
+                    "c": {
+                        "d": {
+                            "e": {
+                                "f": ["foo"]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        regr = ktest_regressions.get_regressions_by_key(key, regressions)
+        self.assertListEqual(["foo"], regr)
+
+    def test_generate_regression_keys(self):
+        regressions = {
+            "lab": {
+                "arch": {
+                    "board": {
+                        "board_instance": {
+                            "defconfig": {
+                                "compiler": ["regression"]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        expected = "lab.arch.board.board_instance.defconfig.compiler"
+
+        for k in ktest_regressions.gen_regression_keys(regressions):
+            self.assertEqual(expected, k)
+
+    def test_sanitize_key(self):
+        self.assertIsNone(None, ktest_regressions.sanitize_key(None))
+        self.assertEqual("", ktest_regressions.sanitize_key(" "))
+
+        key = "foo"
+        self.assertEqual("foo", ktest_regressions.sanitize_key(key))
+
+        key = "foo bar"
+        self.assertEqual("foobar", ktest_regressions.sanitize_key(key))
+
+        key = "foo.bar"
+        self.assertEqual("foo:bar", ktest_regressions.sanitize_key(key))
+
+        key = "foo bar.baz+foo"
+        self.assertEqual("foobar:baz+foo", ktest_regressions.sanitize_key(key))
+
+    @mock.patch("utils.db.find_one3")
+    @mock.patch("utils.db.get_db_connection")
+    def test_find_no_old_doc(self, mock_db, mock_find):
+        mock_find.side_effects = [self.fail_test, None]
+
+        results = ktest_regressions.find(self._id, {})
+        self.assertTupleEqual((None, None), results)
+
+    def test_create_regressions_key(self):
+        expected = "lab-foo.arm64.arm64-board.none.defconfig-full.None"
+        self.assertEqual(
+            expected, ktest_regressions.create_regressions_key(self.pass_test))

--- a/app/utils/report/templates/test.html
+++ b/app/utils/report/templates/test.html
@@ -89,25 +89,41 @@ pre {
     </table>
 
     <table>
+      {% if t.regressions %}
+      {%- for elem in t.regressions|dictsort %}
+      {%- for key, value in t.regressions.data.iteritems()|sort %}
+      <tr><td width="30"></td><td width="100">{{ key }}</td><td width="400"> {{ value }}</td></tr>
+      {%- endfor %}
+      {%- endfor %}
+      {%- else %}
       {% for tc in t.test_cases -%}
       {%- if 'FAIL' == tc.status %}
-      <tr><td width="30"></td><td width="100">{{ tc.name }}</td><td width="20">{{ tc.status }}</td></tr>
+      <tr><td width="30"></td><td width="100">{{ tc.name }}</td><td width="100">never passed</td></tr>
       {%- endif %}
       {%- endfor %}
+      {%- endif %}
     </table>
     <br/>
 
     {% if t.sub_groups -%}
     {% for sg in t.sub_groups -%}
     <table>
-    <tr><td width="30"></td><td width="100"><strong>{{ sg.name }}</strong></td><td width="100">{{ sg.total_tests }} tests</td><td width="100">{{ sg.total["PASS"] }} PASS</td><td width="100">{{ sg.total["FAIL"] }} FAIL</td><td width="100">{{ sg.total["SKIP"] }} SKIP</td></tr>
+    <tr><td width="30"></td><td width="200"><strong>{{ sg.name }}</strong></td><td width="100">{{ sg.total_tests }} tests</td><td width="100">{{ sg.total["PASS"] }} PASS</td><td width="100">{{ sg.total["FAIL"] }} FAIL</td><td width="100">{{ sg.total["SKIP"] }} SKIP</td></tr>
     </table>
     <table>
+      {% if sg.regressions %}
+      {%- for elem in sg.regressions|dictsort %}
+      {%- for key, value in sg.regressions.data.iteritems()|sort %}
+      <tr><td width="30"></td><td width="100">{{ key }}</td><td width="400"> {{ value }}</td></tr>
+      {%- endfor %}
+      {%- endfor %}
+      {%- else %}
       {% for tc in sg.test_cases -%}
       {%- if 'FAIL' == tc.status %}
-      <tr><td width="30"></td><td width="100">{{ tc.name }}</td><td width="20">{{ tc.status }}</td></tr>
+      <tr><td width="30"></td><td width="100">{{ tc.name }}</td><td width="100">never passed</td></tr>
       {%- endif %}
       {%- endfor %}
+      {%- endif %}
     </table>
     <br/>
     {%- endfor %}

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -30,19 +30,35 @@ Summary
   Test Git:    {{ e.git_url }}
   Test Commit: {{ e.git_commit }}
 {%- endfor %}
-{% for tc in t.test_cases %}
-  {%- if 'FAIL' == tc.status %}
-    * {{ tc.name }}: {{ tc.status }}
-  {%- endif %}
-{%- endfor %}
+{% if t.regressions %}
+  {%- for elem in t.regressions|dictsort %}
+    {%- for key, value in t.regressions.data.iteritems()|sort %}
+    * {{ key }}: {{ value }}
+    {%- endfor %}
+  {%- endfor %}
+{% else %}
+  {% for tc in t.test_cases %}
+    {%- if 'FAIL' == tc.status %}
+    * {{ tc.name }}: never passed
+    {%- endif %}
+  {%- endfor %}
+{%- endif %}
 {% if t.sub_groups %}
   {%- for sg in t.sub_groups %}
     {{ sg.name }} - {{ sg.total_tests }} tests: {{ sg.total["PASS"] }}  PASS, {{ sg.total["FAIL"] }} FAIL, {{ sg.total["SKIP"] }} SKIP
-    {%- for tc in sg.test_cases %}
+    {% if sg.regressions %}
+      {%- for elem in sg.regressions|dictsort %}
+      {%- for key, value in sg.regressions.data.iteritems()|sort %}
+      * {{ key }}: {{ value }}
+      {%- endfor %}
+      {%- endfor %}
+    {%- else %}
+      {%- for tc in sg.test_cases %}
       {%- if 'FAIL' == tc.status %}
-      * {{ tc.name }}: {{ tc.status }}
+      * {{ tc.name }}: never passed
       {%- endif %}
-    {%- endfor %}
+      {%- endfor %}
+    {%- endif %}
   {% endfor %}
 {%- endif %}
 {%- endif %}

--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -56,6 +56,112 @@ TEST_REPORT_FIELDS = [
 ]
 
 
+def _get_case(list_cases, name):
+    """Look for a test case with a given name
+
+    :param list_case: List of test cases from  test group
+    :type list_case: list
+    :param name: Name of a test case
+    :type name: string
+    """
+
+    for d in list_cases:
+        if d['name'] == name:
+            return d
+
+
+def create_regressions_data(test_docs, test_data):
+    """Create the regressions data for the email report.
+
+    Will create a dictionary with all the regressions
+
+    :param test_docs: The regressions data (the list of tests).
+    :type test_docs: list
+    :param test_data: Details about the test results
+    :type test_data: dict
+    :return dict The regressions results in a dictionary.
+    """
+    regr_dict = {}
+
+    # Make sure the test reports in the regressions data structure are
+    # correctly sorted by date, so that the oldest document is the PASS one
+    # and the most recent one is the last FAIL-ed.
+    test_docs.sort(
+        cmp=lambda x, y: cmp(x[models.CREATED_KEY], y[models.CREATED_KEY]))
+
+    ndocs = len(test_docs)
+    last_good = test_docs[0]
+
+    # Check case by case when was the first time it failed
+    for tc in last_good["test_cases"]:
+        for i in range(ndocs-1, 0, -1):
+            post = test_docs[i]
+            prev = test_docs[i-1]
+            post_case = _get_case(post["test_cases"], tc["name"])
+            prev_case = _get_case(prev["test_cases"], tc["name"])
+
+            if prev_case["status"] == ['PASS'] and post_case["status"] == 'FAIL':
+                msg = "last worked in"
+                d = {tc["name"]: "{} {}".format(msg, prev["git_describe"])}
+                regr_dict.update(d)
+                continue
+
+            if prev_case["status"] == ['SKIP'] and post_case["status"] == 'FAIL':
+                msg = "new FAIL, skipped in"
+                d = {tc["name"]: "{} {}".format(msg, prev["git_describe"])}
+                regr_dict.update(d)
+                continue
+
+    return regr_dict
+
+
+def parse_regressions(lab_regressions, group_data):
+    """Parse the regressions data and create a dictionary with the
+    regressions for the report. The dictionary has the test name as key
+    and the last kernel were it worked as value.
+
+    The returned data structure is:
+
+        {
+            "data": {
+                 'test name 1': 'v4.20-rc4-301-g13294fbcd4c1',
+                 'test name 2': 'v4.20-rc4-300-g34caf313b358',
+                 ...
+            }
+        }
+
+    :param lab_regressions: The regressions data for each lab.
+    :type lab_regressions: dict
+    :param group_data: Details about the test results
+    :type group_data: dict
+    :return dict The regressions data structure for the report.
+    """
+    regressions = {}
+    lab_name = group_data.get("lab_name", None)
+    arch_name = group_data.get("arch", None)
+    board_name = group_data.get("board", None)
+
+    for lab, lab_d in lab_regressions.iteritems():
+        if lab_name and lab != lab_name:
+            continue
+
+        for arch, arch_d in lab_d.iteritems():
+            if arch_name and arch_name != arch:
+                continue
+
+            for board, board_d in arch_d.iteritems():
+                if board_name and board_name != board:
+                    continue
+
+                for instance_d in board_d.itervalues():
+                    for defconfig, defconfig_d in instance_d.iteritems():
+                        for compiler, tests in defconfig_d.iteritems():
+                            regr = create_regressions_data(tests, group_data)
+                            regressions.update({"data": regr})
+
+    return regressions
+
+
 def _add_test_group_data(group, database):
     test_cases = []
     for test_case_id in group[models.TEST_CASES_KEY]:
@@ -81,11 +187,24 @@ def _add_test_group_data(group, database):
         for status, count in sub_group_total.iteritems():
             total[status] += count
 
+    # Check regressions
+    reg_doc = database[models.TEST_GROUP_REGRESSIONS_COLLECTION].find_one(
+        {models.JOB_KEY: group[models.JOB_KEY],
+         models.KERNEL_KEY: group[models.KERNEL_KEY],
+         models.GIT_BRANCH_KEY: group[models.GIT_BRANCH_KEY],
+         models.NAME_KEY: group[models.NAME_KEY]})
+
+    if reg_doc:
+        regressions = parse_regressions(reg_doc[models.REGRESSIONS_KEY], group)
+    else:
+        regressions = None
+
     group.update({
         "test_cases": test_cases,
         "sub_groups": sub_groups,
         "total_tests": sum(total.values()),
         "total": total,
+        "regressions": regressions,
     })
 
 
@@ -151,7 +270,10 @@ def create_test_report(data, email_format, db_options,
         subject_str = "Test results for {}/{} - {}".format(job, branch, kernel)
     else:
         plans_string = ", ".join(plans)
-        subject_str = "Test results ({}) for {}/{} - {}".format(plans_string, job, branch, kernel)
+        subject_str = "Test results ({}) for {}/{} - {}".format(plans_string,
+                                                                job,
+                                                                branch,
+                                                                kernel)
 
     git_url, git_commit = (top_groups[0][k] for k in [
         models.GIT_URL_KEY, models.GIT_COMMIT_KEY])


### PR DESCRIPTION
The following changes store the test regressions in the backend and update the test report mail. The implementation is using the same strategy than the boot regressions and some functions should be moved to a common library.
Some notes: 
* It doesn't work with `/test`,  only when adding test via the LAVA callback
* This implementation uses the test case name to report about the regressions, if a test group have two test cases with the same name, it'll lead to false positives. (Two test cases with same name in different test groups is OK)
* Having sub-groups with the same name from different groups or a subgroup with the name of a top group can a also lead to bad results.

A mail with the regressions will look like this:

```
Subject: Test results (simple) for local/master - v4.20-rc4-301-g13294fbcd4c1

Test results for:
  Tree:    local
  Branch:  master
  Kernel:  v4.20-rc4-301-g13294fbcd4c1
  URL:     /home/ana/KernelCI/Git/linux
  Commit:  13294fbcd4c195382a0c708c424cd36e49ff686f
  Test plans: simple

Summary
-------
1 test groups results

1  | simple     | qemu                   | arm64 |   8 total:   3 PASS   5 FAIL   0 SKIP

---
1  | simple     | qemu                   | arm64 |   8 total:   3 PASS   5 FAIL   0 SKIP

  Config:      defconfig
  Lab Name:    lab-ana
  Date:        2018-12-05 13:59:48.909000
  TXT log:     http://storage//local/master/v4.20-rc4-301-g13294fbcd4c1/arm64/defconfig/lab-ana/simple-qemu.txt
  HTML log:    http://storage//local/master/v4.20-rc4-301-g13294fbcd4c1/arm64/defconfig/lab-ana/simple-qemu.html
  Rootfs:      http://storage.kernelci.org/images/rootfs/debian/stretch/20181122.0/arm64/rootfs.cpio.gz

    * ls: last worked in v4.20-rc4-299-gb6839ef26e54

    networking - 3 tests: 2  PASS, 1 FAIL, 0 SKIP

      * ls: last worked in v4.20-rc4-299-gb6839ef26e54

    filesystem - 3 tests: 0  PASS, 3 FAIL, 0 SKIP

      * df: last worked in v4.20-rc4-299-gb6839ef26e54
      * ls: last worked in v4.20-rc4-300-g34caf313b358
      * mount: last worked in v4.20-rc4-300-g34caf313b358

```


Some things to do before merging this:
* Add indexes for the two new collections
* Add unit tests for `/app/utils/kci_test/regressions.py`
* Rebase in the top of other changes (most notably PR #96)
