### PR TITLE
T12459 Remove architecture-specific code

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -24,8 +24,6 @@ ACCEPTED_KEYS = "accepted"
 ADDRESS_KEY = "address"
 AGGREGATE_KEY = "aggregate"
 ARCHITECTURE_KEY = "arch"
-ARM64_ARCHITECTURE_KEY = "arm64"
-ARM_ARCHITECTURE_KEY = "arm"
 ATTACHMENTS_KEY = "attachments"
 BASELINE_KEY = "baseline"
 BOARD_INSTANCE_KEY = "board_instance"
@@ -133,7 +131,6 @@ MAXIMUM_KEY = "maximum"
 MEASUREMENTS_KEY = "measurements"
 METADATA_KEY = "metadata"
 MINIMUM_KEY = "minimum"
-MIPS_ARCHITECTURE_KEY = "mips"
 MISMATCHES_COUNT_KEY = "mismatches_count"
 MISMATCHES_KEY = "mismatches"
 MODULES_DIR_KEY = "modules_dir"
@@ -190,8 +187,6 @@ VMLINUX_FILE_SIZE_KEY = "vmlinux_file_size"
 VMLINUX_TEXT_SIZE_KEY = "vmlinux_text_size"
 WARNINGS_COUNT_KEY = "warnings_count"
 WARNINGS_KEY = "warnings"
-x86_ARCHITECTURE_KEY = "x86"
-x86_64_ARCHITECTURE_KEY = "x86_64"
 
 # Email reporting control fields.
 SEND_BOOT_REPORT_KEY = "boot_report"
@@ -315,14 +310,6 @@ LAVA_METADATA_KEY = "metadata"
 LAVA_FAILURE_COMMENT_KEY = "failure_comment"
 LAVA_DEVICE_ID_KEY = "actual_device_id"
 LAVA_LOG_KEY = "log"
-
-VALID_ARCHITECTURES = [
-    ARM64_ARCHITECTURE_KEY,
-    ARM_ARCHITECTURE_KEY,
-    MIPS_ARCHITECTURE_KEY,
-    x86_64_ARCHITECTURE_KEY,
-    x86_ARCHITECTURE_KEY
-]
 
 # Valid build status.
 VALID_BUILD_STATUS = [

--- a/app/models/boot.py
+++ b/app/models/boot.py
@@ -37,7 +37,9 @@ class BootDocument(modb.BaseDocument):
             kernel,
             defconfig,
             lab_name,
-            git_branch, defconfig_full=None, arch=models.ARM_ARCHITECTURE_KEY):
+            git_branch,
+            defconfig_full,
+            arch):
         """A new BootDocument.
 
         :param board: The name of the board.
@@ -53,7 +55,7 @@ class BootDocument(modb.BaseDocument):
         :param defconfig_full: The full value of the defconfig when it contains
         fragments. Default to the same 'defconfig' value.
         :type defconfig_full: string
-        :param arch: The architecture type, default to 'arm'.
+        :param arch: The architecture type.
         :type arch: string
         """
         self._created_on = None
@@ -238,8 +240,7 @@ class BootDocument(modb.BaseDocument):
                 lab_name = doc_pop(models.LAB_NAME_KEY)
                 git_branch = doc_pop(models.GIT_BRANCH_KEY)
                 defconfig_full = doc_pop(models.DEFCONFIG_FULL_KEY, None)
-                arch = doc_pop(
-                    models.ARCHITECTURE_KEY, models.ARM_ARCHITECTURE_KEY)
+                arch = doc_pop(models.ARCHITECTURE_KEY)
 
                 boot_doc = BootDocument(
                     board,

--- a/app/models/tests/test_boot_model.py
+++ b/app/models/tests/test_boot_model.py
@@ -21,12 +21,14 @@ class TestBootModel(unittest.TestCase):
 
     def test_boot_document_valid_instance(self):
         boot_doc = mboot.BootDocument(
-            "board", "job", "kernel", "defconfig", "lab", "branch")
+            "board", "job", "kernel", "defconfig", "lab", "branch",
+            "defconfig_full", "arch")
         self.assertIsInstance(boot_doc, mbase.BaseDocument)
 
     def test_boot_document_to_dict(self):
         boot_doc = mboot.BootDocument(
-            "board", "job", "kernel", "defconfig", "lab", "branch", arch="arm")
+            "board", "job", "kernel", "defconfig", "lab", "branch",
+            "defconfig_full", "arch")
         boot_doc.id = "id"
         boot_doc.job_id = "job-id"
         boot_doc.created_on = "now"
@@ -69,7 +71,7 @@ class TestBootModel(unittest.TestCase):
 
         expected = {
             "_id": "id",
-            "arch": "arm",
+            "arch": "arch",
             "board": "board",
             "board_instance": "instance",
             "boot_log": "boot-log",

--- a/app/utils/bisect/boot.py
+++ b/app/utils/bisect/boot.py
@@ -64,11 +64,9 @@ def _find_boot_bisect_data(obj_id, start_doc, database, db_options):
     board = start_doc_get(models.BOARD_KEY)
     job = start_doc_get(models.JOB_KEY)
     defconfig = start_doc_get(models.DEFCONFIG_KEY)
-    defconfig_full = start_doc_get(
-        models.DEFCONFIG_FULL_KEY) or defconfig
+    defconfig_full = start_doc_get(models.DEFCONFIG_FULL_KEY) or defconfig
     created_on = start_doc_get(models.CREATED_KEY)
-    arch = start_doc_get(
-        models.ARCHITECTURE_KEY) or models.ARM_ARCHITECTURE_KEY
+    arch = start_doc_get(models.ARCHITECTURE_KEY)
     lab_name = start_doc_get(models.LAB_NAME_KEY)
 
     bisect_doc = mbisect.BootBisectDocument(obj_id)
@@ -233,8 +231,7 @@ def execute_boot_bisection_compared_to(
             defconfig_full = start_doc_get(
                 models.DEFCONFIG_FULL_KEY) or defconfig
             created_on = start_doc_get(models.CREATED_KEY)
-            arch = start_doc_get(
-                models.ARCHITECTURE_KEY) or models.ARM_ARCHITECTURE_KEY
+            arch = start_doc_get(models.ARCHITECTURE_KEY)
             lab_name = start_doc_get(models.LAB_NAME_KEY)
 
             bisect_doc = mbisect.BootBisectDocument(obj_id)

--- a/app/utils/bisect/defconfig.py
+++ b/app/utils/bisect/defconfig.py
@@ -258,8 +258,7 @@ def execute_build_bisection_compared_to(
             defconfig_full = start_doc_get(
                 models.DEFCONFIG_FULL_KEY) or defconfig
             created_on = start_doc_get(models.CREATED_KEY)
-            arch = start_doc_get(
-                models.ARCHITECTURE_KEY) or models.ARM_ARCHITECTURE_KEY
+            arch = start_doc_get(models.ARCHITECTURE_KEY)
             branch = start_doc_get(models.GIT_BRANCH_KEY)
 
             bisect_doc = mbisect.DefconfigBisectDocument(obj_id)

--- a/app/utils/boot/__init__.py
+++ b/app/utils/boot/__init__.py
@@ -410,14 +410,7 @@ def _parse_boot_from_json(boot_json, database, errors):
         return None
 
     defconfig_full = boot_json.get(models.DEFCONFIG_FULL_KEY, defconfig)
-    arch = boot_json.get(models.ARCHITECTURE_KEY, models.ARM_ARCHITECTURE_KEY)
-
-    if arch not in models.VALID_ARCHITECTURES:
-        err_msg = "Invalid architecture found: %s".format(arch)
-        utils.LOG.error(err_msg)
-        ERR_ADD(errors, 400, err_msg)
-        return None
-
+    arch = boot_json.get(models.ARCHITECTURE_KEY)
     boot_doc = mboot.BootDocument(
         board,
         job, kernel, defconfig, lab_name, git_branch, defconfig_full, arch)

--- a/app/utils/boot/tests/test_boot_import.py
+++ b/app/utils/boot/tests/test_boot_import.py
@@ -96,15 +96,6 @@ class TestParseBoot(unittest.TestCase):
         self.assertEqual(doc.boot_job_id, "1234")
         self.assertIsInstance(doc.metadata, types.DictionaryType)
 
-    def test_parse_from_json_default_arch(self):
-        errors = {}
-        self.boot_report.pop("arch")
-
-        doc = bimport._parse_boot_from_json(self.boot_report, self.db, errors)
-
-        self.assertIsInstance(doc, mboot.BootDocument)
-        self.assertEqual(doc.arch, "arm")
-
     def test_check_for_null_with_none(self):
         boot_report = {
             "job": None,
@@ -195,9 +186,8 @@ class TestParseBoot(unittest.TestCase):
             "git_branch": "branch"
         }
         boot_doc = mboot.BootDocument(
-            "board",
-            "job",
-            "kernel", "defconfig", "lab", "branch", "defconfig+FRAGMENT")
+            "board", "job", "kernel", "defconfig", "lab", "branch",
+            "defconfig+FRAGMENT", "arm")
         expected_path = os.path.join(
             base_path,
             "job", "branch", "kernel", "arm", "defconfig+FRAGMENT", "lab")
@@ -224,9 +214,8 @@ class TestParseBoot(unittest.TestCase):
             "lab_name": "lab"
         }
         boot_doc = mboot.BootDocument(
-            "board",
-            "job",
-            "kernel", "defconfig", "lab", "branch", "defconfig+FRAGMENT")
+            "board", "job", "kernel", "defconfig", "lab", "branch",
+            "defconfig+FRAGMENT", "arm")
         expected_path = os.path.join(
             base_path,
             "job", "branch", "kernel", "arm", "defconfig+FRAGMENT", "lab")
@@ -261,9 +250,8 @@ class TestParseBoot(unittest.TestCase):
             "git_branch": "branch"
         }
         boot_doc = mboot.BootDocument(
-            "board",
-            "job",
-            "kernel", "defconfig", "lab", "branch", "defconfig+FRAGMENT")
+            "board", "job", "kernel", "defconfig", "lab", "branch",
+            "defconfig+FRAGMENT", "arm")
         expected_path = os.path.join(
             base_path,
             "job", "branch", "kernel", "arm", "defconfig+FRAGMENT", "lab")

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -481,13 +481,6 @@ def _parse_test_group_from_json(test_json, database, errors):
         return None
 
     arch = test_json.get(models.ARCHITECTURE_KEY)
-
-    if arch not in models.VALID_ARCHITECTURES:
-        err_msg = "Invalid architecture found: %s".format(arch)
-        utils.LOG.error(err_msg)
-        ERR_ADD(errors, 400, err_msg)
-        return None
-
     test_doc = mtest_group.TestGroupDocument(name, lab_name)
     test_doc.created_on = datetime.datetime.now(tz=bson.tz_util.utc)
     _update_test_group_doc_from_json(test_doc, test_json, errors)


### PR DESCRIPTION
CPU architecture names are specific data that is not useful to have in
the logic of the code.  If we wanted to make the backend aware of
existing architectures, we could have a collection for that or some
kind of configuration.  But this doesn't seem to be adding any value,
in the same way that we don't keep a list of other kind of data such
as existing hardware platforms or compiler variants.

Having a hard-coded list of architectures in the code also makes it
harder to add new ones (RISC-V, ARC...).

For these reasons, remove any hard-coded reference to CPU
architectures and remove the default "arm" value.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>