### PR TITLE
T12512 regressions with multiple compilers

### DIFF
--- a/app/models/bisect.py
+++ b/app/models/bisect.py
@@ -50,6 +50,8 @@ class BisectDocument(modb.BaseDocument):
         self.defconfig = None
         self.defconfig_full = None
         self.compiler = None
+        self.compiler_version = None
+        self.build_environment = None
         self.build_id = None
 
     @property
@@ -129,6 +131,8 @@ class BisectDocument(modb.BaseDocument):
             models.DEFCONFIG_FULL_KEY: self.defconfig_full,
             models.DEFCONFIG_KEY: self.defconfig,
             models.COMPILER_KEY: self.compiler,
+            models.COMPILER_VERSION_KEY: self.compiler_version,
+            models.BUILD_ENVIRONMENT_KEY: self.build_environment,
             models.BUILD_ID_KEY: self.build_id,
         }
 

--- a/app/models/tests/test_bisect_model.py
+++ b/app/models/tests/test_bisect_model.py
@@ -72,6 +72,8 @@ class TestBisectModel(unittest.TestCase):
             "defconfig": None,
             "defconfig_full": None,
             "compiler": None,
+            "compiler_version": None,
+            "build_environment": None,
             "git_branch": None,
             "git_url": None,
         }
@@ -107,6 +109,8 @@ class TestBisectModel(unittest.TestCase):
             "defconfig": None,
             "defconfig_full": None,
             "compiler": None,
+            "compiler_version": None,
+            "build_environment": None,
             "git_branch": None,
             "git_url": None,
         }
@@ -148,6 +152,8 @@ class TestBisectModel(unittest.TestCase):
             "job_id": "job-id",
             "type": "boot",
             "compiler": None,
+            "compiler_version": None,
+            "build_environment": None,
             "lab_name": "secret-lab",
             "arch": None,
             "device_type": "qemu",
@@ -213,6 +219,9 @@ class TestBisectModel(unittest.TestCase):
         bisect_doc.found_summary = "7890cdef foo: change bar into baz"
         bisect_doc.kernel = "v4.56"
         bisect_doc.git_url = "https://somewhere.com/blah.git"
+        bisect_doc.compiler = "randomcc"
+        bisect_doc.compiler_version = "123.456"
+        bisect_doc.build_environment = "build-env"
 
         expected = {
             "_id": "bar",
@@ -233,7 +242,9 @@ class TestBisectModel(unittest.TestCase):
             "defconfig": "defconfig-name",
             "job_id": "job-id",
             "defconfig_full": "defconfig-full",
-            "compiler": None,
+            "compiler": "randomcc",
+            "compiler_version": "123.456",
+            "build_environment": "build-env",
             "arch": "arm",
             "type": "build",
             "git_branch": None,

--- a/app/utils/bisect/boot.py
+++ b/app/utils/bisect/boot.py
@@ -343,6 +343,8 @@ def create_boot_bisect(good, bad, db_options):
     doc.defconfig = bad[models.DEFCONFIG_KEY]
     doc.defconfig_full = bad[models.DEFCONFIG_FULL_KEY]
     doc.compiler = bad[models.COMPILER_KEY]
+    doc.compiler_version = bad[models.COMPILER_VERSION_KEY]
+    doc.build_environment = bad[models.BUILD_ENVIRONMENT_KEY]
     doc.build_id = bad[models.BUILD_ID_KEY]
     doc.lab_name = bad[models.LAB_NAME_KEY]
     doc.device_type = bad[models.DEVICE_TYPE_KEY]

--- a/app/utils/boot/regressions.py
+++ b/app/utils/boot/regressions.py
@@ -62,7 +62,12 @@ def create_regressions_key(boot_doc):
         sanitize_key(str(b_get(models.BOARD_INSTANCE_KEY)).lower())
     board = sanitize_key(b_get(models.BOARD_KEY))
     build_env = b_get(models.BUILD_ENVIRONMENT_KEY)
-    compiler = sanitize_key(str(b_get(models.COMPILER_VERSION_EXT_KEY)))
+    compiler_name = b_get(models.COMPILER_KEY)
+    compiler_version = b_get(models.COMPILER_VERSION_KEY)
+    compiler = sanitize_key(
+        "-".join([compiler_name, compiler_version])
+        if compiler_version else compiler_name
+    )
     defconfig = sanitize_key(b_get(models.DEFCONFIG_FULL_KEY))
     lab = b_get(models.LAB_NAME_KEY)
 
@@ -198,7 +203,12 @@ def track_regression(boot_doc, pass_doc, old_regr, db_options):
     b_instance = sanitize_key(str(b_get(models.BOARD_INSTANCE_KEY)).lower())
     board = sanitize_key(b_get(models.BOARD_KEY))
     build_env = b_get(models.BUILD_ENVIRONMENT_KEY)
-    compiler = sanitize_key(str(b_get(models.COMPILER_VERSION_EXT_KEY)))
+    compiler_name = b_get(models.COMPILER_KEY)
+    compiler_version = b_get(models.COMPILER_VERSION_KEY)
+    compiler = sanitize_key(
+        "-".join([compiler_name, compiler_version])
+        if compiler_version else compiler_name
+    )
     defconfig = sanitize_key(b_get(models.DEFCONFIG_FULL_KEY))
     job = b_get(models.JOB_KEY)
     job_id = b_get(models.JOB_ID_KEY)
@@ -324,8 +334,8 @@ def check_and_track(boot_doc, db_options):
     spec = {
         models.ARCHITECTURE_KEY: b_get(models.ARCHITECTURE_KEY),
         models.BOARD_KEY: b_get(models.BOARD_KEY),
-        models.COMPILER_VERSION_EXT_KEY:
-            b_get(models.COMPILER_VERSION_EXT_KEY),
+        models.COMPILER_VERSION_FULL_KEY:
+            b_get(models.COMPILER_VERSION_FULL_KEY),
         models.CREATED_KEY: {"$lt": b_get(models.CREATED_KEY)},
         models.DEFCONFIG_FULL_KEY: b_get(models.DEFCONFIG_FULL_KEY),
         models.DEFCONFIG_KEY: b_get(models.DEFCONFIG_KEY),

--- a/app/utils/boot/tests/test_boot_regressions.py
+++ b/app/utils/boot/tests/test_boot_regressions.py
@@ -38,7 +38,8 @@ class TestBootRegressions(unittest.TestCase):
             "defconfig_full": "defconfig-full",
             "defconfig": "defconfig",
             "build_environment": "gcc",
-            "compiler_version_ext": "gcc 5.1.1",
+            "compiler": "gcc",
+            "compiler_version": "5.1.1",
             "lab_name": "boot-lab",
             "board": "arm-board",
             "created_on": "2016-06-29"
@@ -52,7 +53,8 @@ class TestBootRegressions(unittest.TestCase):
             "defconfig_full": "defconfig-full",
             "defconfig": "defconfig",
             "build_environment": "gcc",
-            "compiler_version_ext": "gcc 5.1.1",
+            "compiler": "gcc",
+            "compiler_version": "5.1.1",
             "lab_name": "boot-lab",
             "board": "arm-board",
             "created_on": "2016-06-28"
@@ -177,6 +179,6 @@ class TestBootRegressions(unittest.TestCase):
         self.assertTupleEqual((None, None), results)
 
     def test_create_regressions_key(self):
-        expected = "boot-lab.arm.arm-board.none.defconfig-full.gcc.gcc5:1:1"
+        expected = "boot-lab.arm.arm-board.none.defconfig-full.gcc.gcc-5:1:1"
         self.assertEqual(
             expected, boot_regressions.create_regressions_key(self.pass_boot))

--- a/app/utils/boot/tests/test_boot_regressions.py
+++ b/app/utils/boot/tests/test_boot_regressions.py
@@ -37,6 +37,7 @@ class TestBootRegressions(unittest.TestCase):
             "arch": "arm",
             "defconfig_full": "defconfig-full",
             "defconfig": "defconfig",
+            "build_environment": "gcc",
             "compiler_version_ext": "gcc 5.1.1",
             "lab_name": "boot-lab",
             "board": "arm-board",
@@ -50,6 +51,7 @@ class TestBootRegressions(unittest.TestCase):
             "arch": "arm",
             "defconfig_full": "defconfig-full",
             "defconfig": "defconfig",
+            "build_environment": "gcc",
             "compiler_version_ext": "gcc 5.1.1",
             "lab_name": "boot-lab",
             "board": "arm-board",
@@ -123,14 +125,16 @@ class TestBootRegressions(unittest.TestCase):
                     "board": {
                         "board_instance": {
                             "defconfig": {
-                                "compiler": ["regression"]
+                                "build_env": {
+                                    "compiler": ["regression"]
+                                }
                             }
                         }
                     }
                 }
             }
         }
-        expected = "lab.arch.board.board_instance.defconfig.compiler"
+        expected = "lab.arch.board.board_instance.defconfig.build_env.compiler"
 
         for k in boot_regressions.gen_regression_keys(regressions):
             self.assertEqual(expected, k)
@@ -173,6 +177,6 @@ class TestBootRegressions(unittest.TestCase):
         self.assertTupleEqual((None, None), results)
 
     def test_create_regressions_key(self):
-        expected = "boot-lab.arm.arm-board.none.defconfig-full.gcc5:1:1"
+        expected = "boot-lab.arm.arm-board.none.defconfig-full.gcc.gcc5:1:1"
         self.assertEqual(
             expected, boot_regressions.create_regressions_key(self.pass_boot))

--- a/app/utils/build/__init__.py
+++ b/app/utils/build/__init__.py
@@ -391,6 +391,7 @@ def _traverse_build_dir(build_dir, job_doc, errors, database):
                     utils.LOG.exception(e.from_exc)
                 utils.LOG.error(e.args[0])
                 ERR_ADD(errors, e.code, e.args[0])
+                return
 
             build_doc.job_id = job_doc.id
             # Search for previous defconfig doc. This is only useful when

--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -496,8 +496,14 @@ def _start_bisection(bisection, jopts):
         "KERNEL_NAME": models.KERNEL_KEY,
         "GOOD_COMMIT": models.BISECT_GOOD_COMMIT_KEY,
         "BAD_COMMIT": models.BISECT_BAD_COMMIT_KEY,
+        "CC": models.COMPILER_KEY,
+        "CC_VERSION": models.COMPILER_VERSION_KEY,
+        "BUILD_ENVIRONMENT": models.BUILD_ENVIRONMENT_KEY,
     }
-    params = {k: bisection[v] for k, v in params_map.iteritems()}
+    params = {
+        k: v for (k, v) in (
+            (k, bisection.get(x)) for k, x in params_map.iteritems()) if v
+    }
     utils.LOG.info("Triggering bisection for {}/{}, board: {}, lab: {}".format(
         params["KERNEL_TREE"], params["KERNEL_BRANCH"],
         params["TARGET"], params["LAB"]))

--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -553,7 +553,6 @@ def _parse_boot_results(results, intersect_results=None, get_unique=False):
     of intersections found or 0, and the unique data or None.
     """
     parsed_data = {}
-    parsed_get = parsed_data.get
     unique_data = None
     intersections = 0
 
@@ -568,12 +567,12 @@ def _parse_boot_results(results, intersect_results=None, get_unique=False):
         arch = res_get(models.ARCHITECTURE_KEY)
         defconfig = res_get(models.DEFCONFIG_FULL_KEY)
         status = res_get(models.STATUS_KEY)
-        build_environment = res_get(models.BUILD_ENVIRONMENT_KEY)
+        build_env = res_get(models.BUILD_ENVIRONMENT_KEY)
 
         result_struct = {
             arch: {
                 defconfig: {
-                    build_environment: {
+                    build_env: {
                         board: {
                             lab_name: status
                         }
@@ -590,38 +589,38 @@ def _parse_boot_results(results, intersect_results=None, get_unique=False):
                 defconfig_view = intersect_results[arch].viewkeys()
 
                 if defconfig in defconfig_view:
-                    build_environment_view = \
+                    build_env_view = \
                         intersect_results[arch][defconfig].viewkeys()
                     irad = intersect_results[arch][defconfig]
-                    if build_environment in build_environment_view:
-                        if irad[build_environment].get(board, None):
+                    if build_env in build_env_view:
+                        if irad[build_env].get(board, None):
                             intersections += 1
-                            del irad[build_environment][board]
+                            del irad[build_env][board]
                             # Clean up also the remainder of the data structure
                             # so that we really have cleaned up data.
-                            if not irad[build_environment]:
-                                del irad[build_environment]
+                            if not irad[build_env]:
+                                del irad[build_env]
                             if not intersect_results[arch]:
                                 del intersect_results[arch]
 
-        if arch in parsed_data.viewkeys():
-            if defconfig in parsed_get(arch).viewkeys():
-                if build_environment in parsed_get(defconfig).viewkeys():
-                    if board in parsed_get(arch)[defconfig].viewkeys():
-                        pgad = parsed_get(arch)[defconfig]
-                        pgadb = pgad[build_environment]
+        if arch in parsed_data:
+            if defconfig in parsed_data[arch]:
+                if build_env in parsed_data[arch][defconfig]:
+                    if board in parsed_data[arch][defconfig][build_env]:
+                        pgad = parsed_data[arch][defconfig]
+                        pgadb = pgad[build_env]
                         rsad = result_struct[arch][defconfig]
-                        if build_environment in pgadb[board].viewkeys():
+                        if build_env in pgadb[board]:
                             pgadb[board][lab_name] = \
-                                rsad[build_environment][board][lab_name]
+                                rsad[build_env][board][lab_name]
                     else:
-                        parsed_get(arch)[defconfig][board] = \
-                            result_struct[arch][defconfig][board]
+                        parsed_data[arch][defconfig][build_env][board] = \
+                            result_struct[arch][defconfig][build_env][board]
                 else:
-                    parsed_get(arch)[defconfig][build_environment] = \
-                        result_struct[arch][defconfig][build_environment]
+                    parsed_data[arch][defconfig][build_env] = \
+                        result_struct[arch][defconfig][build_env]
             else:
-                parsed_get(arch)[defconfig] = result_struct[arch][defconfig]
+                parsed_data[arch][defconfig] = result_struct[arch][defconfig]
         else:
             parsed_data[arch] = result_struct[arch]
 

--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -171,12 +171,14 @@ def parse_regressions(lab_regressions, boot_data, db_options):
             "data": {
                 "arch": {
                     "defconfig": {
-                        "board": [
-                            {
-                                "txt": "string",
-                                "html": "string"
-                            },
-                        ]
+                        "build_environment": {
+                            "board": [
+                                {
+                                    "txt": "string",
+                                    "html": "string"
+                                },
+                            ]
+                        }
                     }
                 }
             }
@@ -211,14 +213,19 @@ def parse_regressions(lab_regressions, boot_data, db_options):
                     for defconfig, defconfig_d in instance_d.iteritems():
                         defconfig = unicode(defconfig)
                         regr_def = regr_arch.setdefault(defconfig, {})
-                        regr_board = regr_def.setdefault(board, [])
-                        for compiler, boots in defconfig_d.iteritems():
-                            good, bad = boots[0], boots[-1]
-                            bisect = bbisect.create_boot_bisect(
-                                good, bad, db_options)
-                            bisections.append(bisect)
-                            regr = create_regressions_data(boots, boot_data)
-                            regr_board.append(regr)
+                        for build_env, build_env_d in defconfig_d.iteritems():
+                            regr_build_env = regr_def.setdefault(
+                                build_env, {})
+                            for compiler, boots in build_env_d.iteritems():
+                                regr_board = regr_build_env.setdefault(
+                                    board, [])
+                                good, bad = boots[0], boots[-1]
+                                bisect = bbisect.create_boot_bisect(
+                                    good, bad, db_options)
+                                bisections.append(bisect)
+                                regr = create_regressions_data(
+                                    boots, boot_data)
+                                regr_board.append(regr)
 
     # Remove duplicate entries - they are dictionaries so filter them by _id
     bisections = {b['_id']: b for b in bisections}.values()

--- a/app/utils/report/templates/boot.html
+++ b/app/utils/report/templates/boot.html
@@ -29,20 +29,23 @@
                 <tr><td><strong>{{ summary }}</strong></td></tr>
         {%- endfor %}
                 <tr><td style="padding-bottom: 10px;"></td></tr>
-        {%- for arch, data in regressions.data|dictsort %}
+        {%- for arch, arch_data in regressions.data|dictsort %}
                 <tr><td>{{ arch }}:</td></tr>
-        {%- for defconfig, boards_data in data|dictsort %}
+        {%- for defconfig, build_env_data in arch_data|dictsort %}
                 <tr>
                     <td style="padding-left: 20px; padding-top: 10px;">
                     {{ defconfig }}:
                     </td>
                 </tr>
-        {%- for board, labs_data in boards_data|dictsort %}
-                <tr><td style="padding-left: 40px;">{{ board }}:</td></tr>
+        {%- for build_env, board_data in build_env_data|dictsort %}
+                <tr><td style="padding-left: 40px;">{{ build_env }}:</td></tr>
+        {%- for board, labs_data in board_data|dictsort %}
+                <tr><td style="padding-left: 55px;">{{ board }}:</td></tr>
         {%- for lab in labs_data %}
-                <tr><td style="padding-left: 55px;">{{ lab.html }}</td></tr>
+                <tr><td style="padding-left: 70px;">{{ lab.html }}</td></tr>
         {%- endfor %}{# lab #}
         {%- endfor %}{# board #}
+        {%- endfor %}{# build_env #}
         {%- endfor %}{# defconfig #}
         {%- endfor %}{# arch #}
             </tbody>
@@ -65,8 +68,9 @@
                     </td>
                 </tr>
             {%- for build_environment in platforms.failed_data.data[arch][defconfig] %}
+                <tr><td style="padding-left: 40px;">{{ build_environment }}:</td></tr>
             {%- for board in platforms.failed_data.data[arch][defconfig][build_environment] %}
-                <tr><td style="padding-left: 40px;">{{ build_environment }}: {{ board[1] }}</td></tr>
+                <tr><td style="padding-left: 55px;">{{ board[1] }}</td></tr>
             {%- endfor %}{# board #}
             {%- endfor %}{# build_environment #}
             {%- endfor %}{# defconfig #}

--- a/app/utils/report/templates/boot.txt
+++ b/app/utils/report/templates/boot.txt
@@ -15,16 +15,19 @@
 {%- for summary in regressions.summary.txt %}
 {{ summary }}
 {%- endfor %}
-{% for arch, data in regressions.data|dictsort %}
+{% for arch, arch_data in regressions.data|dictsort %}
 {{ arch }}:
-{% for defconfig, boards_data in data|dictsort %}
+{% for defconfig, build_env_data in arch_data|dictsort %}
     {{ defconfig }}:
-{%- for board, labs_data in boards_data|dictsort %}
-        {{ board }}:
+{%- for build_env, board_data in build_env_data|dictsort %}
+        {{ build_env }}:
+{%- for board, labs_data in board_data|dictsort %}
+          {{ board }}:
 {%- for lab in labs_data %}
-            {{ lab.txt }}
+              {{ lab.txt }}
 {%- endfor %}{# lab #}
 {%- endfor %}{# board #}
+{%- endfor %}{# build_env #}
 {% endfor %}{# defconfig #}
 {%- endfor %}{# arch #}
 {%- endif %}{# regressions #}
@@ -36,9 +39,9 @@
 {% for arch in platforms.failed_data.data %}{# boot failures #}
 {{ arch }}:
 {% for defconfig in platforms.failed_data.data[arch] %}
-    {{ defconfig }}
+    {{ defconfig }}:
 {%- for build_environment in platforms.failed_data.data[arch][defconfig] %}
-        {{ build_environment }}
+        {{ build_environment }}:
 {%- for board in platforms.failed_data.data[arch][defconfig][build_environment] %}
             {{ board[0] }}
 {%- endfor %}{# board #}


### PR DESCRIPTION
Store original compiler name and version directly from the received build meta-data.  This can then be used to track regressions and trigger bisections using the same parameters as when doing kernel builds with `CC` and `CC_VERSION`.  It also avoids having boot regressions stored with a `None` compiler key.

Also enforce `BuildDocument.git_branch` to be a required field.  It is part of the mandatory keys in build POST requests, but the rest of the code wasn't treating it as such.

Note: This depends on #86.