### PR TITLE
T12407 Include single test plan in test reports

### DIFF
--- a/app/handlers/send.py
+++ b/app/handlers/send.py
@@ -62,7 +62,7 @@ REPORT_TYPE_KEYS = {
         models.JOB_KEY,
         models.GIT_BRANCH_KEY,
         models.KERNEL_KEY,
-        models.PLANS_KEY,
+        models.PLAN_KEY,
     ],
 }
 
@@ -94,10 +94,6 @@ class SendHandler(hbase.BaseHandler):
         countdown = j_get(models.DELAY_KEY)
         if countdown is None:
             countdown = self.settings["senddelay"]
-
-        plans = j_get(models.PLANS_KEY)
-        if plans is None:
-            plans = []
 
         # Deprecated - ToDo: use report_type only in client code
         if j_get(models.SEND_BOOT_REPORT_KEY):
@@ -367,11 +363,11 @@ class SendHandler(hbase.BaseHandler):
         has_errors = False
         error_string = None
 
-        job, git_branch, kernel, plans = (report_data[k] for k in [
+        job, git_branch, kernel, plan = (report_data[k] for k in [
             models.JOB_KEY,
             models.GIT_BRANCH_KEY,
             models.KERNEL_KEY,
-            models.PLANS_KEY
+            models.PLAN_KEY
         ])
 
         if email_opts.get("to"):
@@ -380,7 +376,7 @@ class SendHandler(hbase.BaseHandler):
                     job,
                     git_branch,
                     kernel,
-                    plans,
+                    plan,
                     report_data,
                     email_opts,
                 ],
@@ -390,8 +386,8 @@ class SendHandler(hbase.BaseHandler):
             has_errors = True
             error_string = "No email addresses provided to send test report to"
             self.log.error(
-                "%s for '%s-%s-%s-plans_%s'",
-                error_string, job, git_branch, kernel, "_".join(plans))
+                "%s for '%s-%s-%s-plan_%s'",
+                error_string, job, git_branch, kernel, plan)
 
         return has_errors, error_string
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -199,7 +199,7 @@ REPORT_CC_KEY = "send_cc"
 REPORT_BCC_KEY = "send_bcc"
 DELAY_KEY = "delay"
 IN_REPLY_TO_KEY = "in_reply_to"
-PLANS_KEY = "plans"
+PLAN_KEY = "plan"
 
 # Token special fields.
 ADMIN_KEY = "admin"
@@ -744,7 +744,7 @@ SEND_VALID_KEYS = {
         MANDATORY_KEYS: [
             GIT_BRANCH_KEY,
             JOB_KEY,
-            KERNEL_KEY
+            KERNEL_KEY,
         ],
         ACCEPTED_KEYS: [
             DELAY_KEY,
@@ -754,7 +754,7 @@ SEND_VALID_KEYS = {
             JOB_KEY,
             KERNEL_KEY,
             LAB_NAME_KEY,
-            PLANS_KEY,
+            PLAN_KEY,
             REPORT_TYPE_KEY,
             REPORT_BCC_KEY,
             REPORT_CC_KEY,

--- a/app/taskqueue/tasks/report.py
+++ b/app/taskqueue/tasks/report.py
@@ -179,7 +179,7 @@ def send_bisect_report(report_data, email_opts, base_path=utils.BASE_PATH):
 
 
 @taskc.app.task(name="send-test-report")
-def send_test_report(job, git_branch, kernel, plans, report_data, email_opts):
+def send_test_report(job, git_branch, kernel, plan, report_data, email_opts):
     """Send the tests report email.
 
     :param job: The job name.
@@ -188,19 +188,15 @@ def send_test_report(job, git_branch, kernel, plans, report_data, email_opts):
     :type git_branch: string
     :param kernel: The kernel name.
     :type kernel: string
-    :param plans: List of plans to include in the report.
-    :type plans: list
+    :param plan: Test plan to include in the report.
+    :type plan: string
     :param report_data: The data necessary for generating a report.
     :type report_data: dict
     :param email_opts: Email options.
     :type email_opts: dict
     """
-    if not plans:
-        report_id = "-".join([job, git_branch, kernel])
-    else:
-        report_id = "-".join([job, git_branch, kernel] + plans)
-    utils.LOG.info(
-        "Sending tests report email for '{}'".format(report_id))
+    report_id = "-".join([job, git_branch, kernel, plan])
+    utils.LOG.info("Sending tests report email for '{}'".format(report_id))
 
     db_options = taskc.app.conf.get("db_options", {})
 

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -1,3 +1,5 @@
+{{ subject_str }}
+
 Test results summary
 --------------------
 
@@ -6,7 +8,7 @@ Test results summary
   Kernel:  {{ kernel }}
   URL:     {{ git_url }}
   Commit:  {{ git_commit }}
-  Tests:   {{ plans_string }}
+  Test:    {{ plan }}
 
 {% for t in test_groups|sort(attribute='name') %}
 {{ "%-2s | %-10s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.name, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}


### PR DESCRIPTION
Rather than including a number of test plans in each test report,
include only one to make the report analogous to "build" and "boot",
for example only "igt" or "v4l2".  Also make it mandatory to specify
the test plan as a result.

Combined with the new parent_id field, this makes it possible to
simplify the logic to find the top-level test groups for the test
report.

Also align the email subject with other reports showing the total
number of tests and regressions.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>