### PR TITLE
kci_test: fix group_doc_id exception

### DIFF
--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -609,6 +609,7 @@ def import_and_save_kci_tests(group, db_options, base_path=utils.BASE_PATH):
     :return operation code (201 if success, 500 in case of an error), the group
     document ID and a dictionary with errors.
     """
+    group_doc_id = None
     ret_code = 500
     errors = {}
 


### PR DESCRIPTION
In the case where the 'try' clause fails (e.g. due to db connection
error, group_doc_id is referenced before assignment.  Example exception
included below.

Fix that by setting a default value.

[   ERROR/MainThread] Error getting database connection
[   ERROR/MainThread] Task lava-test[36027fe5-70ff-493d-843c-abf46048a025] raised unexpected: UnboundLocalError("local variable 'group_doc_id' referenced before assignment",)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/user/kernelci-backend/app/taskqueue/tasks/callback.py", line 52, in lava_test
    taskc.app.conf.db_options)
  File "/home/user/kernelci-backend/app/utils/callback/lava.py", line 556, in add_tests
    utils.kci_test.import_and_save_kci_tests(group, db_options)
  File "/home/user/kernelci-backend/app/utils/kci_test/__init__.py", line 642, in import_and_save_kci_tests
    return ret_code, group_doc_id, errors
UnboundLocalError: local variable 'group_doc_id' referenced before assignment
[   ERROR/MainThread] Task failed, UUID: 36027fe5-70ff-493d-843c-abf46048a025, error: local variable 'group_doc_id' referenced before assignment

Signed-off-by: Kevin Hilman <khilman@baylibre.com>