### PR TITLE
T12645 test plan options v4l2-compliance

### DIFF
--- a/app/utils/report/templates/plans/v4l2-compliance.txt
+++ b/app/utils/report/templates/plans/v4l2-compliance.txt
@@ -1,0 +1,13 @@
+{% extends 'test.txt' %}
+
+{% block plan_description %}
+V4L2 Compliance on the {{ driver_name }} driver.
+
+This test ran "v4l2-compliance -s" from v4l-utils:
+
+    https://www.linuxtv.org/wiki/index.php/V4l2-utils
+
+See each detailed section in the report below to find out the git URL and
+particular revision that was used to build the test binaries.
+
+{% endblock %}

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -2,13 +2,13 @@
 
 Test results summary
 --------------------
-
+{% block plan_description %}
+  Test:    {{ plan }}{% endblock %}
   Tree:    {{ tree }}
   Branch:  {{ branch }}
   Kernel:  {{ kernel }}
   URL:     {{ git_url }}
   Commit:  {{ git_commit }}
-  Test:    {{ plan }}
 
 {% for t in test_groups|sort(attribute='name') %}
 {{ "%-2s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -11,7 +11,7 @@ Test results summary
   Test:    {{ plan }}
 
 {% for t in test_groups|sort(attribute='name') %}
-{{ "%-2s | %-10s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.name, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
+{{ "%-2s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
 {%- endfor %}
 
 
@@ -19,7 +19,7 @@ Test failures
 -------------
 {%- for t in test_groups|sort(attribute='name') %} {# test_groups #}
   {%- if t.total["FAIL"] or t.regressions %} {# fail or regressions #}
-{{ "%-2s | %-10s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.name, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
+{{ "%-2s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
 
   Config:      {{ t.defconfig_full }}
   Compiler:    {{ t.build_environment }}{% if t.compiler_version_full %} ({{ t.compiler_version_full }}){% endif %}


### PR DESCRIPTION
Add the possibility to have a test email report template and some options specific to some test plans.  This is to make it possible to show arbitrary information such as a description of the tests being run in the email report, and have more flexibility in the email subject than just the plain test plan name.

Ideally, these options should be set in the YAML test plan definition.  This can't be easily used in the kernelci-backend code at the moment, so until a solution has been found a Python dictionary is used in the test.py source code.

Some ideas for a better approach may be to group the kernelci-core and some of the kernelci-backend features (results parsing, regression tracking, bisections, email reports) or split the YAML configuration into a separate repository which would be shared between kernelci-core and kernelci-backend.

Depends on https://github.com/kernelci/kernelci-core-staging/pull/86