### PR TITLE
T12348 duplicate bisections

### DIFF
--- a/app/utils/bisect/boot.py
+++ b/app/utils/bisect/boot.py
@@ -311,6 +311,7 @@ def create_boot_bisect(good, bad, db_options):
     database = utils.db.get_db_connection(db_options)
     good_commit, bad_commit = (b[models.GIT_COMMIT_KEY] for b in (good, bad))
     spec = {x: bad[x] for x in [
+        models.LAB_NAME_KEY,
         models.DEVICE_TYPE_KEY,
         models.ARCHITECTURE_KEY,
         models.DEFCONFIG_FULL_KEY,


### PR DESCRIPTION
This PR does 2 things to avoid reporting the same bisection results more than once:

* Limit the number of bisections run with a same good/bad commit range to 3.
The idea being that only one is enough to report a problem, but 3 is a good number in case some of them fail due to infrastructure errors.

* Do not send bisection reports with the same found git commit and related kernel revision more than once.
Regardless of how a bisection was run, if there has been a previous bisection report with the same git commit found and the same initial kernel regression, then subsequent reports are not sent.