### PR TITLE
Ensure the measurements display in the email reports

### DIFF
--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -47,6 +47,12 @@ Test failures
       * {{ tc.name }}: {{ tc.failure_message }}
           {%- endif %}
         {%- endfor %}
+        {%- for tc in sg.test_cases %}
+          {%- if tc.measurements %}
+      * {{ tc.name }}:
+        Measurements: {{ tc.measurements[0]['value'] }} {{ tc.measurements[0]['unit'] }}
+          {%- endif %}
+        {%- endfor %}
       {%- endif %} {# sg fail or regressions #}
     {%- endfor %} {# sub_groups #}
   {%- endif %} {# fail or regressions #}


### PR DESCRIPTION
This patch adds a support to the 'test.txt' template to report the
test case measurement if there is one.

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>