### PR TITLE
Ensure the measurements display in the email reports

### DIFF
--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -38,6 +38,12 @@ Test failures
     * {{ tc.name }}: {{ tc.failure_message }}
       {%- endif %}
     {%- endfor %}
+    {%- for tc in t.test_cases %}
+      {%- if tc.measurements %}
+    * {{ tc.name }}:
+      Measurements: {{ tc.measurements[0]['value'] }} {{ tc.measurements[0]['unit'] }}
+      {%- endif %}
+    {%- endfor %}
     {%- for sg in t.sub_groups %} {# sub_groups #}
       {%- if sg.total["FAIL"] or sg.regressions %} {# sg fail or regressions #}
 
@@ -45,6 +51,12 @@ Test failures
         {%- for tc in sg.test_cases %}
           {%- if 'FAIL' == tc.status %}
       * {{ tc.name }}: {{ tc.failure_message }}
+          {%- endif %}
+        {%- endfor %}
+        {%- for tc in sg.test_cases %}
+          {%- if tc.measurements %}
+      * {{ tc.name }}:
+        Measurements: {{ tc.measurements[0]['value'] }} {{ tc.measurements[0]['unit'] }}
           {%- endif %}
         {%- endfor %}
       {%- endif %} {# sg fail or regressions #}


### PR DESCRIPTION
This patch adds a support to the 'test.txt' template to report test case
measurement if there is one.

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>