### PR TITLE
Fix boot conflicts python exception

### DIFF
--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -623,6 +623,8 @@ def _parse_boot_results(results, intersect_results=None, get_unique=False):
                             # so that we really have cleaned up data.
                             if not irad[build_env]:
                                 del irad[build_env]
+                            if not intersect_results[arch][defconfig]:
+                                del intersect_results[arch][defconfig]
                             if not intersect_results[arch]:
                                 del intersect_results[arch]
 
@@ -630,11 +632,11 @@ def _parse_boot_results(results, intersect_results=None, get_unique=False):
             if defconfig in parsed_data[arch]:
                 if build_env in parsed_data[arch][defconfig]:
                     if board in parsed_data[arch][defconfig][build_env]:
-                        pgad = parsed_data[arch][defconfig]
-                        pgadb = pgad[build_env]
+                        pdad = parsed_data[arch][defconfig]
+                        pdadb = pdad[build_env]
                         rsad = result_struct[arch][defconfig]
-                        if build_env in pgadb[board]:
-                            pgadb[board][lab_name] = \
+                        if lab_name not in pdadb[board]:
+                            pdadb[board][lab_name] = \
                                 rsad[build_env][board][lab_name]
                     else:
                         parsed_data[arch][defconfig][build_env][board] = \
@@ -1269,10 +1271,6 @@ def _parse_and_structure_results(boot_data):
             offline_data, offline_struct["data"], is_offline=True)
     else:
         parsed_data["offline_data"] = None
-
-    if conflict_data:
-        utils.LOG.warn("Skipping conflict data due to known bug")
-        conflict_data = None
 
     if conflict_data:
         parsed_data["conflict_data"] = {}

--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -1161,12 +1161,12 @@ def _parse_and_structure_results(boot_data):
                             board_struct = defconf_struct[
                                 (txt_string, html_string)
                             ]
-                            for lab in def_get(board).viewkeys():
-                                board_struct.append(
+                            for lab in build_get(board).viewkeys():
+                                board_struct.append((
                                     G_(u"{:s}: {:s}").format(
-                                        lab, def_get(board)[lab]),
+                                        lab, build_get(board)[lab]),
                                     build_environment
-                                )
+                                ))
                     else:
                         # Not a conflict data structure, we show only the count
                         # of the failed labs, not which one failed.

--- a/app/utils/report/templates/boot.html
+++ b/app/utils/report/templates/boot.html
@@ -62,11 +62,7 @@
             {%- for arch in platforms.failed_data.data %}
                 <tr><td>{{ arch }}:</td></tr>
             {%- for defconfig in platforms.failed_data.data[arch] %}
-                <tr>
-                    <td style="padding-left: 20px; padding-top: 10px;">
-                        {{ defconfig }}:
-                    </td>
-                </tr>
+                <tr><td style="padding-left: 20px;">{{ defconfig }}:</td></tr>
             {%- for build_environment in platforms.failed_data.data[arch][defconfig] %}
                 <tr><td style="padding-left: 40px;">{{ build_environment }}:</td></tr>
             {%- for board in platforms.failed_data.data[arch][defconfig][build_environment] %}
@@ -113,11 +109,7 @@
             {%- for arch in platforms.conflict_data.data %}
                 <tr><td>{{ arch }}</td></tr>
             {%- for defconfig in platforms.conflict_data.data[arch] %}
-                <tr>
-                    <td style="padding-left: 20px; padding-top: 10px;">
-                        {{ defconfig }}:
-                    </td>
-                </tr>
+                <tr><td style="padding-left: 20px;">{{ defconfig }}:</td></tr>
             {%- for board in platforms.conflict_data.data[arch][defconfig] %}
                 <tr><td style="padding-left: 40px">{{ board[0] }}:</td></tr>
             {%- for lab in platforms.conflict_data.data[arch][defconfig][board] %}

--- a/app/utils/report/templates/boot.html
+++ b/app/utils/report/templates/boot.html
@@ -119,9 +119,9 @@
                     </td>
                 </tr>
             {%- for board in platforms.conflict_data.data[arch][defconfig] %}
-                <tr><td style="padding-left: 40px">{{ board[1] }} ({{ board[2] }}):</td></tr>
+                <tr><td style="padding-left: 40px">{{ board[0] }}:</td></tr>
             {%- for lab in platforms.conflict_data.data[arch][defconfig][board] %}
-                <tr><td style="padding-left: 55px;">{{ lab }}</td></tr>
+                <tr><td style="padding-left: 55px;">{{ lab[0] }} ({{ lab[1] }})</td></tr>
             {%- endfor %}{# lab #}
             {%- endfor %}{# board #}
             {%- endfor %}{# defconfig #}

--- a/app/utils/report/templates/boot.txt
+++ b/app/utils/report/templates/boot.txt
@@ -75,9 +75,9 @@
 {% for defconfig in platforms.conflict_data.data[arch] %}
     {{ defconfig }}:
 {%- for board in platforms.conflict_data.data[arch][defconfig] %}
-        {{ board[0] }} ({{ board[1] }}):
+        {{ board[0] }}:
 {%- for lab in platforms.conflict_data.data[arch][defconfig][board] %}
-            {{ lab }}
+            {{ lab[0] }} ({{ lab[1] }})
 {%- endfor %}{# lab #}
 {%- endfor %}{# board #}
 {% endfor %}{# defconfig #}

--- a/app/utils/report/templates/boot.txt
+++ b/app/utils/report/templates/boot.txt
@@ -38,7 +38,7 @@
 {%- endfor %}
 {% for arch in platforms.failed_data.data %}{# boot failures #}
 {{ arch }}:
-{% for defconfig in platforms.failed_data.data[arch] %}
+{%- for defconfig in platforms.failed_data.data[arch] %}
     {{ defconfig }}:
 {%- for build_environment in platforms.failed_data.data[arch][defconfig] %}
         {{ build_environment }}:
@@ -72,7 +72,7 @@
 {%- endfor %}
 {% for arch in platforms.conflict_data.data %}
 {{ arch }}:
-{% for defconfig in platforms.conflict_data.data[arch] %}
+{%- for defconfig in platforms.conflict_data.data[arch] %}
     {{ defconfig }}:
 {%- for board in platforms.conflict_data.data[arch][defconfig] %}
         {{ board[0] }}:


### PR DESCRIPTION
When adding the build_environment, the boot conflict rendering
code was not updated, so any emails with a conflict were not being
sent.