### PR TITLE
Print "Test failures" header only when there are any

### DIFF
--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -15,10 +15,15 @@ Test results summary
 {%- endfor %}
 
 
-Test failures
--------------
+{%- set print_header = true %}
 {%- for t in test_groups|sort(attribute='name') %} {# test_groups #}
   {%- if t.total["FAIL"] or t.regressions %} {# fail or regressions #}
+    {% if print_header %}
+
+Test failures
+-------------
+        {%- set print_header = false %}
+    {%- endif %} {# print_header #}
 {{ "%-2s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
 
   Config:      {{ t.defconfig_full }}


### PR DESCRIPTION
This change removes "Test failures" header when there are no failed test cases, so no-one is confused.

Test reports after the changed is applied.

No failures:

```
local/mgalka v4l2-compliance on vivid: 117 tests, 0 regressions (kernelci-local-snapshot-032-4-g0227673db427)

Test results summary
--------------------

V4L2 Compliance on the vivid driver.

This test ran "v4l2-compliance -s" from v4l-utils:

    https://www.linuxtv.org/wiki/index.php/V4l2-utils

See each detailed section in the report below to find out the git URL and
particular revision that was used to build the test binaries.


  Tree:    local
  Branch:  mgalka
  Kernel:  kernelci-local-snapshot-032-4-g0227673db427
  URL:     /home/mgalka/projects/linux
  Commit:  0227673db4276f18039a294fbd1efd46a6826f62


1  | qemu                   | arm64 | 117 total:  84 PASS   0 FAIL  33 SKIP

```

4 failed tests:

```


local/mgalka v4l2-compliance on vivid: 117 tests, 4 regressions (kernelci-local-snapshot-032-5-g06335288a25d)

Test results summary
--------------------

V4L2 Compliance on the vivid driver.

This test ran "v4l2-compliance -s" from v4l-utils:

    https://www.linuxtv.org/wiki/index.php/V4l2-utils

See each detailed section in the report below to find out the git URL and
particular revision that was used to build the test binaries.


  Tree:    local
  Branch:  mgalka
  Kernel:  kernelci-local-snapshot-032-5-g06335288a25d
  URL:     /home/mgalka/projects/linux
  Commit:  06335288a25d4ee508a952f80725282e2b245947


1  | qemu                   | arm64 | 117 total:  80 PASS   4 FAIL  33 SKIP  
    

Test failures
------------- 
1  | qemu                   | arm64 | 117 total:  80 PASS   4 FAIL  33 SKIP

  Config:      defconfig+virtualvideo
  Compiler:    gcc (aarch64-linux-gnu-gcc (Ubuntu/Linaro 7.3.0-27ubuntu1~18.04) 7.3.0)
  Lab Name:    mgalka-lava-local
  Plain log:   http://kernelci//local/mgalka/kernelci-local-snapshot-032-5-g06335288a25d/arm64/defconfig+virtualvideo/gcc/mgalka-lava-local/v4l2-compliance-vivid-qemu.txt
  HTML log:    http://kernelci//local/mgalka/kernelci-local-snapshot-032-5-g06335288a25d/arm64/defconfig+virtualvideo/gcc/mgalka-lava-local/v4l2-compliance-vivid-qemu.html
  Rootfs:      http://storage.kernelci.org/images/rootfs/debian/stretch-v4l2/20190213.0/arm64/rootfs.cpio.gz
  Test Git:    git://linuxtv.org/v4l-utils.git
  Test Commit: aa371c995ec2ad70323db00c47b3132002b060b7
                              

    Control-ioctls-Input-3 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427)   

    Control-ioctls-Input-2 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427)   

    Control-ioctls-Input-1 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427)   

    Control-ioctls-Input-0 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427)             

```