### PR TITLE
Fix failed test cases order in the report.

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -108,6 +108,7 @@ GTE_KEY = "gte"
 HIERARCHY_KEY = "hierarchy"
 ID_KEY = "_id"
 IMAGE_TYPE_KEY = "image_type"
+INDEX_KEY = "index"
 INITRD_ADDR_KEY = "initrd_addr"
 INITRD_INFO_KEY = "initrd_info"
 INITRD_KEY = "initrd"
@@ -897,6 +898,7 @@ TEST_CASE_VALID_KEYS = {
             CREATED_KEY,
             DEFINITION_URI_KEY,
             KVM_GUEST_KEY,
+            INDEX_KEY,
             MAXIMUM_KEY,
             MEASUREMENTS_KEY,
             METADATA_KEY,
@@ -919,6 +921,7 @@ TEST_CASE_VALID_KEYS = {
         CREATED_KEY,
         DEFINITION_URI_KEY,
         KVM_GUEST_KEY,
+        INDEX_KEY,
         MAXIMUM_KEY,
         MEASUREMENTS_KEY,
         METADATA_KEY,
@@ -939,6 +942,7 @@ TEST_CASE_VALID_KEYS = {
         CREATED_KEY,
         DEFINITION_URI_KEY,
         KVM_GUEST_KEY,
+        INDEX_KEY,
         MAXIMUM_KEY,
         MINIMUM_KEY,
         NAME_KEY,

--- a/app/models/test_case.py
+++ b/app/models/test_case.py
@@ -51,6 +51,7 @@ class TestCaseDocument(mbase.BaseDocument):
         self._measurements = []
         self._parameters = {}
 
+        self.index = None
         self.definition_uri = None
         self.kvm_guest = None
         self.maximum = None
@@ -236,6 +237,7 @@ class TestCaseDocument(mbase.BaseDocument):
             models.CREATED_KEY: self.created_on,
             models.DEFINITION_URI_KEY: self.definition_uri,
             models.KVM_GUEST_KEY: self.kvm_guest,
+            models.INDEX_KEY: self.index,
             models.MAXIMUM_KEY: self.maximum,
             models.MEASUREMENTS_KEY: self.measurements,
             models.METADATA_KEY: self.metadata,

--- a/app/models/tests/test_test_case_model.py
+++ b/app/models/tests/test_test_case_model.py
@@ -31,6 +31,7 @@ class TestTestCaseModel(unittest.TestCase):
         test_case.attachments = [{"foo": "bar"}]
         test_case.created_on = "now"
         test_case.definition_uri = "scheme://authority/path"
+        test_case.index = 1
         test_case.kvm_guest = "kvm_guest"
         test_case.maximum = 1
         test_case.measurements = [{"foo": 1}]
@@ -52,6 +53,7 @@ class TestTestCaseModel(unittest.TestCase):
             "attachments": [{"foo": "bar"}],
             "created_on": "now",
             "definition_uri": "scheme://authority/path",
+            "index": 1,
             "kvm_guest": "kvm_guest",
             "maximum": 1,
             "measurements": [{"foo": 1}],
@@ -78,6 +80,7 @@ class TestTestCaseModel(unittest.TestCase):
         test_case.attachments = [{"foo": "bar"}]
         test_case.created_on = "now"
         test_case.definition_uri = "scheme://authority/path"
+        test_case.index = 1
         test_case.kvm_guest = "kvm_guest"
         test_case.maximum = 1
         test_case.measurements = [{"foo": 1}]
@@ -98,6 +101,7 @@ class TestTestCaseModel(unittest.TestCase):
             "attachments": [{"foo": "bar"}],
             "created_on": "now",
             "definition_uri": "scheme://authority/path",
+            "index": 1,
             "kvm_guest": "kvm_guest",
             "maximum": 1,
             "measurements": [{"foo": 1}],
@@ -136,6 +140,7 @@ class TestTestCaseModel(unittest.TestCase):
             "attachments": [{"foo": "bar"}],
             "created_on": "now",
             "definition_uri": "scheme://authority/path",
+            "index": 1,
             "kvm_guest": "kvm_guest",
             "maximum": 1,
             "measurements": [{"foo": 1}],

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -44,6 +44,7 @@ LAVA_JOB_RESULT = {
 TEST_CASE_MAP = {
     models.NAME_KEY: "name",
     models.STATUS_KEY: "result",
+    models.INDEX_KEY: "logged",
 }
 
 TEST_CASE_NAME_EXTRA = {
@@ -432,7 +433,7 @@ def _add_test_results(group, suite_results, suite_name):
     test_cases = []
     test_sets = {}
 
-    for test in tests:
+    for test in reversed(tests):
         test_case = {
             models.VERSION_KEY: "1.1",
             models.TIME_KEY: "0.0",
@@ -446,6 +447,7 @@ def _add_test_results(group, suite_results, suite_name):
             test_case_list = test_sets.setdefault(test_set_name, [])
         else:
             test_case_list = test_cases
+        test_case[models.INDEX_KEY] = len(test_case_list) + 1
         measurement = test.get("measurement")
         if measurement and measurement != 'None':
             test_case[models.MEASUREMENTS_KEY] = [{

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -215,6 +215,7 @@ def _update_test_case_doc_from_json(case_doc, test_dict, errors):
 
     case_doc.definition_uri = test_dict.get(models.DEFINITION_URI_KEY, None)
     case_doc.kvm_guest = test_dict.get(models.KVM_GUEST_KEY, None)
+    case_doc.index = test_dict.get(models.INDEX_KEY, None)
     case_doc.maximum = test_dict.get(models.MAXIMUM_KEY, None)
     case_doc.measurements = test_dict.get(models.MEASUREMENTS_KEY, [])
     case_doc.metadata = test_dict.get(models.METADATA_KEY, None)

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -43,7 +43,7 @@ Test failures
     * {{ tc.name }}: {{ tc.failure_message }}
       {%- endif %}
     {%- endfor %}
-    {%- for sg in t.sub_groups %} {# sub_groups #}
+    {%- for sg in t.sub_groups|sort(attribute='test_cases.0.index') %} {# sub_groups #}
       {%- if sg.total["FAIL"] or sg.regressions %} {# sg fail or regressions #}
 
     {{ sg.name }} - {{ sg.total_tests }} tests: {{ sg.total["PASS"] }}  PASS, {{ sg.total["FAIL"] }} FAIL, {{ sg.total["SKIP"] }} SKIP

--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -13,9 +13,6 @@
 
 """Create the tests email report."""
 
-import json
-import os
-
 import models
 import utils
 import utils.db
@@ -113,6 +110,8 @@ def _add_test_group_data(group, db, spec, hierarchy=[]):
             if regr:
                 regr_count += 1
         test_cases.append(test_case)
+
+    test_cases.sort(key=lambda tc: tc[models.INDEX_KEY])
 
     sub_groups = []
     for sub_group_id in group[models.SUB_GROUPS_KEY]:


### PR DESCRIPTION
This change adds "index" field to the TestCase document. The field is supposed to be used for test case ordering.
For LAVA test results the index field stores the "logged" timestamp, but it can store any other value in case other test backend is used.
This commit adds also sub groups sorting in the e-mail test report. It sorts the test subgroups by the "index" value of the first test case in the subgroup.

The aim of the provided changes is to avoid  e-mail report presenting failed test cases in a different order that they were run by the test backend.

The changes should be enough for LAVA, however they may occur insufficient for test backends that run test groups asynchronously.

Failed test cases report before changes:
```
Test failures
------------- 
1  | qemu                   | arm64 | 117 total:  80 PASS   4 FAIL  33 SKIP

  Config:      defconfig+virtualvideo
  Compiler:    gcc (aarch64-linux-gnu-gcc (Ubuntu/Linaro 7.3.0-27ubuntu1~18.04) 7.3.0)
  Lab Name:    mgalka-lava-local
  Plain log:   http://kernelci//local/mgalka/kernelci-local-snapshot-032-5-gcbdb192f6a76/arm64/defconfig+virtualvideo/gcc/mgalka-lava-local/v4l2-compliance-vivid-qemu.txt
  HTML log:    http://kernelci//local/mgalka/kernelci-local-snapshot-032-5-gcbdb192f6a76/arm64/defconfig+virtualvideo/gcc/mgalka-lava-local/v4l2-compliance-vivid-qemu.html
  Rootfs:      http://storage.kernelci.org/images/rootfs/debian/stretch-v4l2/20190213.0/arm64/rootfs.cpio.gz
  Test Git:    git://linuxtv.org/v4l-utils.git
  Test Commit: aa371c995ec2ad70323db00c47b3132002b060b7
                

    Control-ioctls-Input-0 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427) 

    Control-ioctls-Input-2 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427) 

    Control-ioctls-Input-1 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427) 

    Control-ioctls-Input-3 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427) 
```

Failed test cases report after changes:
```
Test failures
------------- 
1  | qemu                   | arm64 | 117 total:  80 PASS   4 FAIL  33 SKIP

  Config:      defconfig+virtualvideo
  Compiler:    gcc (aarch64-linux-gnu-gcc (Ubuntu/Linaro 7.3.0-27ubuntu1~18.04) 7.3.0)
  Lab Name:    mgalka-lava-local
  Plain log:   http://kernelci//local/mgalka/kernelci-local-snapshot-032-5-gcbdb192f6a76/arm64/defconfig+virtualvideo/gcc/mgalka-lava-local/v4l2-compliance-vivid-qemu.txt
  HTML log:    http://kernelci//local/mgalka/kernelci-local-snapshot-032-5-gcbdb192f6a76/arm64/defconfig+virtualvideo/gcc/mgalka-lava-local/v4l2-compliance-vivid-qemu.html
  Rootfs:      http://storage.kernelci.org/images/rootfs/debian/stretch-v4l2/20190213.0/arm64/rootfs.cpio.gz
  Test Git:    git://linuxtv.org/v4l-utils.git
  Test Commit: aa371c995ec2ad70323db00c47b3132002b060b7
              

    Control-ioctls-Input-0 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427)           

    Control-ioctls-Input-1 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427)     

    Control-ioctls-Input-2 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427)             

    Control-ioctls-Input-3 - 6 tests: 4  PASS, 1 FAIL, 1 SKIP
      * VIDIOC_QUERYCTRL: new failure (last pass: kernelci-local-snapshot-032-4-g0227673db427) 
```
