### PR TITLE
Fixed lab document delete handler

### DIFF
--- a/app/handlers/lab.py
+++ b/app/handlers/lab.py
@@ -120,7 +120,7 @@ class LabHandler(handlers.base.BaseHandler):
                 lab_bson_id = bson.objectid.ObjectId(lab_id)
 
                 lab_doc = utils.db.find_one2(
-                    self.collection, {models.ID_KEY, lab_bson_id})
+                    self.collection, {models.ID_KEY: lab_bson_id})
 
                 if lab_doc:
                     token_id = lab_doc.get(models.TOKEN_KEY, None)


### PR DESCRIPTION
Changed find_one2 parameter type from set to dict. Probably a typo that slipped under the radar long time ago.