### PR TITLE
Skip boot conflict data in reports as it's currently broken

### DIFF
--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -1271,6 +1271,10 @@ def _parse_and_structure_results(boot_data):
         parsed_data["offline_data"] = None
 
     if conflict_data:
+        utils.LOG.warn("Skipping conflict data due to known bug")
+        conflict_data = None
+
+    if conflict_data:
         parsed_data["conflict_data"] = {}
         conflict_struct = parsed_data["conflict_data"]
 


### PR DESCRIPTION
Work around a known bug with boot reports whereby an exception is
raised whenever there is a boot conflict.  This regression was
introduced with support for multiple compilers.  It is causing many
boot emails to not be sent and as a side effects some bisections are
not being triggered.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>