### PR TITLE
requirements.txt: pin down the version of sphinxcontrib-httpdomain

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ redis==2.10.6
 scandir
 simplejson
 sphinx-bootstrap-theme
-sphinxcontrib-httpdomain
+sphinxcontrib-httpdomain==1.3.0
 tornado==3.2.2


### PR DESCRIPTION
Pin down the version of sphinxcontrib-httpdomain to 1.3.0 as more
recent versions are not compatible with Sphinx 1.4.9 which is already
pinned down.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>