### PR TITLE
Add compiler information in the test report

### DIFF
--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -11,7 +11,7 @@ Test results summary
   Commit:  {{ git_commit }}
 
 {% for t in test_groups|sort(attribute='name') %}
-{{ "%-2s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
+{{ "%-2s | %-22s | %-8s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.board, t.build_environment, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
 {%- endfor %}
 
 
@@ -24,7 +24,7 @@ Test failures
 -------------
         {%- set print_header = false %}
     {%- endif %} {# print_header #}
-{{ "%-2s | %-22s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.board, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
+{{ "%-2s | %-22s | %-8s | %-5s | %3s total: %3s PASS %3s FAIL %3s SKIP"|format(loop.index, t.board, t.build_environment, t.arch, t.total_tests, t.total["PASS"], t.total["FAIL"], t.total["SKIP"]) }}
 
   Config:      {{ t.defconfig_full }}
   Compiler:    {{ t.build_environment }}{% if t.compiler_version_full %} ({{ t.compiler_version_full }}){% endif %}


### PR DESCRIPTION
Added build environment information in test reports.

Before:
```
[...]
1  | qemu                   | arm64 | 118 total:  78 PASS   7 FAIL  33 SKIP
2  | qemu                   | arm64 | 118 total:  78 PASS   7 FAIL  33 SKIP  

Test failures
------------- 
1  | qemu                   | arm64 | 118 total:  78 PASS   7 FAIL  33 SKIP
[...]
Test failures
------------- 
2  | qemu                   | arm64 | 118 total:  78 PASS   7 FAIL  33 SKIP
[...]
```

After:
```
Test failures
------------- 
1  | qemu                   | gcc        | arm64 | 118 total:  78 PASS   7 FAIL  33 SKIP

[...]

Test failures
------------- 
2  | qemu                   | gcc-8      | arm64 | 118 total:  78 PASS   7 FAIL  33 SKIP
[...]
```