### PR TITLE
add a new 'test_template' object in the POST/send API

### DIFF
--- a/app/handlers/send.py
+++ b/app/handlers/send.py
@@ -112,6 +112,7 @@ class SendHandler(hbase.BaseHandler):
             return response
         report_data = {k: j_get(k) for k in report_keys}
 
+        test_template = j_get(models.TEST_TEMPLATE, None)
         email_format = j_get(models.EMAIL_FORMAT_KEY, None)
         email_format, email_errors = _check_email_format(email_format)
         response.errors = email_errors
@@ -154,6 +155,7 @@ class SendHandler(hbase.BaseHandler):
                 "in_reply_to": j_get(models.IN_REPLY_TO_KEY),
                 "subject": j_get(models.SUBJECT_KEY),
                 "format": email_format,
+                "test_template": test_template,
             }
 
             report_type_or_plan = j_get(models.PLAN_KEY, report_type)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -171,6 +171,7 @@ TEST_JOB_PATH_KEY = "test_job_path"
 TEST_JOB_URL_KEY = "test_job_url"
 TEST_GROUP_ID_KEY = "test_group_id"
 TEST_GROUP_NAME_KEY = "test_group_name"
+TEST_TEMPLATE = "test_template"
 TEXT_OFFSET_KEY = "text_offset"
 TIME_KEY = "time"
 TIME_RANGE_KEY = "time_range"
@@ -771,6 +772,7 @@ SEND_VALID_KEYS = {
             SEND_BOOT_REPORT_KEY,
             SEND_BUILD_REPORT_KEY,
             SUBJECT_KEY,
+            TEST_TEMPLATE,
             # Bisection keys
             TYPE_KEY,
             ARCHITECTURE_KEY,

--- a/app/taskqueue/tasks/report.py
+++ b/app/taskqueue/tasks/report.py
@@ -201,7 +201,7 @@ def send_test_report(job, git_branch, kernel, plan, report_data, email_opts):
     db_options = taskc.app.conf.get("db_options", {})
 
     test_report = utils.report.test.create_test_report(
-        report_data, email_opts["format"], db_options)
+        report_data, email_opts["format"], email_opts["test_template"], db_options)
 
     if test_report is None:
         return 500

--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -15,6 +15,7 @@
 
 import models
 import utils
+import os
 import utils.db
 import utils.report.common as rcommon
 
@@ -139,7 +140,7 @@ def _add_test_group_data(group, db, spec, hierarchy=[]):
     })
 
 
-def create_test_report(data, email_format, db_options,
+def create_test_report(data, email_format, test_template, db_options,
                        base_path=utils.BASE_PATH):
     """Create the tests report email to be sent.
 
@@ -224,7 +225,19 @@ def create_test_report(data, email_format, db_options,
         "test_groups": groups,
     }
 
-    template = plan_options.get("template", "test.txt")
+    if test_template:
+        path = os.getcwd() + "/utils/report/templates"
+        templates = [t for t in os.listdir(path)]
+        test_template = str(test_template) + ".txt"
+        if test_template in templates:
+            template = test_template
+        else:
+            utils.LOG.warning("%s: this template does not exist" % str(
+                test_template))
+            return None
+    else:
+        template = "test.txt"
+
     template_data.update(plan_options.get("params", {}))
     body = rcommon.create_txt_email(template, **template_data)
 


### PR DESCRIPTION
This patch adds a new 'test_template' object in the POST/send API in
order to diversify the use of the test email report feature. So this
gives the ability to choose which are the test results want to be
reported by choosing the test template.

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>