### PR TITLE
Use the ATTACHMENTS_KEY

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -438,21 +438,24 @@ def _add_test_results(group, suite_results, suite_name):
             models.TIME_KEY: "0.0",
         }
         test_case.update({k: test[v] for k, v in TEST_CASE_MAP.iteritems()})
-        test_meta = test["metadata"]
-        if suite_name == "lava":
-            _parse_lava_test_data(test_case, test_meta)
-        test_set_name = test_meta.get("set")
-        if test_set_name:
-            test_case_list = test_sets.setdefault(test_set_name, [])
-        else:
-            test_case_list = test_cases
-        test_case[models.INDEX_KEY] = len(test_case_list) + 1
         measurement = test.get("measurement")
         if measurement and measurement != 'None':
             test_case[models.MEASUREMENTS_KEY] = [{
                 "value": float(measurement),
                 "unit": test["unit"],
             }]
+        test_meta = test["metadata"]
+        if suite_name == "lava":
+            _parse_lava_test_data(test_case, test_meta)
+        reference = test_meta.get("reference")
+        if reference:
+            test_case[models.ATTACHMENTS_KEY] = [reference]
+        test_set_name = test_meta.get("set")
+        if test_set_name:
+            test_case_list = test_sets.setdefault(test_set_name, [])
+        else:
+            test_case_list = test_cases
+        test_case[models.INDEX_KEY] = len(test_case_list) + 1
         test_case_list.append(test_case)
 
     sub_groups = []

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -218,6 +218,7 @@ def _update_test_case_doc_from_json(case_doc, test_dict, errors):
     case_doc.index = test_dict.get(models.INDEX_KEY, None)
     case_doc.maximum = test_dict.get(models.MAXIMUM_KEY, None)
     case_doc.measurements = test_dict.get(models.MEASUREMENTS_KEY, [])
+    case_doc.attachments = test_dict.get(models.ATTACHMENTS_KEY, [])
     case_doc.metadata = test_dict.get(models.METADATA_KEY, None)
     case_doc.minimum = test_dict.get(models.MINIMUM_KEY, None)
     case_doc.samples = test_dict.get(models.SAMPLES_KEY, None)


### PR DESCRIPTION
THis patch use the ATTACHMENTS_KEY to collect the reference data from a
lava job which is a link to a file geneated in the test_case.

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>