### PR TITLE
Add new /tests/group API handler

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -127,6 +127,7 @@ LAB_ID_KEY = "lab_id"
 LAB_NAME_KEY = "lab_name"
 LIMIT_KEY = "limit"
 LOAD_ADDR_KEY = "load_addr"
+LOG_KEY = 'log'
 LT_KEY = "lt"
 MACH_ALIAS_KEY = "mach_alias"
 MACH_KEY = "mach"
@@ -814,10 +815,14 @@ BISECT_VALID_KEYS = {
 TEST_GROUP_VALID_KEYS = {
     "POST": {
         MANDATORY_KEYS: [
-            BUILD_ID_KEY,
+            ARCHITECTURE_KEY,
+            BUILD_ENVIRONMENT_KEY,
+            DEFCONFIG_KEY,
+            GIT_BRANCH_KEY,
+            JOB_KEY,
+            KERNEL_KEY,
             LAB_NAME_KEY,
             NAME_KEY,
-            BUILD_ENVIRONMENT_KEY,
         ],
         ACCEPTED_KEYS: [
             ARCHITECTURE_KEY,
@@ -827,10 +832,15 @@ TEST_GROUP_VALID_KEYS = {
             BUILD_ENVIRONMENT_KEY,
             CREATED_KEY,
             DEFCONFIG_FULL_KEY,
+            DEVICE_TYPE_KEY,
             BUILD_ID_KEY,
             DEFCONFIG_KEY,
             DEFINITION_URI_KEY,
+            ENDIANNESS_KEY,
+            FILE_SERVER_RESOURCE_KEY,
+            GIT_COMMIT_KEY,
             GIT_BRANCH_KEY,
+            IMAGE_TYPE_KEY,
             INDEX_KEY,
             INITRD_KEY,
             INITRD_INFO_KEY,
@@ -838,9 +848,13 @@ TEST_GROUP_VALID_KEYS = {
             JOB_KEY,
             KERNEL_KEY,
             LAB_NAME_KEY,
+            LOG_KEY,
+            MACH_KEY,
             METADATA_KEY,
             NAME_KEY,
+            SUB_GROUPS_KEY,
             TEST_CASES_KEY,
+            TIME_KEY,
             VCS_COMMIT_KEY,
             VERSION_KEY
         ]

--- a/app/urls.py
+++ b/app/urls.py
@@ -172,6 +172,11 @@ _TEST_GROUP_URL = tornado.web.url(
     handlers.test_group.TestGroupHandler, name="test-group"
 )
 
+_TEST_RESULT_URL = tornado.web.url(
+    r"/test[s]?",
+    handlers.test_group.TestGroupHandler, name="test-result"
+)
+
 _TEST_GROUP_DISTINCT_URL = tornado.web.url(
     r"/test[s]?/group[s]?/distinct/(?P<field>[A-Za-z0-9_]+)/?$",
     handlers.distinct.DistinctHandler,
@@ -249,6 +254,7 @@ APP_URLS = [
     _TEST_GROUP_COUNT_DISTINCT_URL,
     _TEST_GROUP_DISTINCT_URL,
     _TEST_GROUP_URL,
+    _TEST_RESULT_URL,
     _TOKEN_URL,
     _UPLOAD_URL,
     _VERSION_URL

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -14,8 +14,11 @@
 """Container for all the kci_test import related functions."""
 
 import bson
+import codecs
 import copy
 import datetime
+import errno
+import os
 import pymongo
 
 import models
@@ -127,6 +130,19 @@ def save_or_update(doc, spec_map, collection, database, errors):
         ERR_ADD(errors, ret_val, err_msg)
 
     return ret_val, doc_id
+
+
+def _add_test_log(dir_path, filename, log_data):
+    utils.LOG.info("Generating log files in {}".format(filename))
+    if not os.path.isdir(dir_path):
+        try:
+            os.makedirs(dir_path)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise e
+    logfile_path = os.path.join(dir_path, filename)
+    with codecs.open(logfile_path, "w", "utf-8") as logfile:
+        logfile.write(log_data)
 
 
 def _check_for_null(test_dict, NON_NULL_KEYS):


### PR DESCRIPTION
This PR contains changes of /tests/ API handling. It makes use of `kci_test` package to keep lava and non-lava test results consistent.

The POST method handler for `/test/group` endpoint has been heavily redesigned. At the moment it doesn't simply create the test_group document when called. At the moment it accepts `test_group` JSON that can contain sub groups (nested test_group JSONs) and test cases in a form of `test_case` documents.

The `/test[s]` endpoint calls the same code as `/test[s]/group` endpoint at the moment and can be used to post test results.

Handler implementation uses the same mechanisms as lava callback implementation to determine which `build` was used for the test.

The test group JSON may contain `'log'` field. Data from the `log` wield are treated as a text log file and saved as provided by the backend.

The easiest way to test current API is to call curl with appropriate data.


Examples:
- Test group document without sub groups and test cases
```
curl -X POST  http://kernelci:5001/test \
    -H 'Content-Type: application/json' \
    -H 'Authorization: KERNELCI_API_TOKEN' \
    -d @- <<'EOF'
     {
        "sub_groups": [],
        "board": "fake-board",
        "build_environment": "gcc-8",
        "name": "Fake-test-group-with-test-cases",
        "metadata": {},
        "initrd_info": null,
        "git_branch": "fake-branch",
        "git_commit": "feeddeadbeef",
        "version": "1.0",
        "mach": null,
        "board_instance": null,
        "job": "fake-job",
        "file_server_resource": null,
        "initrd": null,
        "device_type": "fake-device-type",
        "arch": "fake-arm64",
        "kernel" : "kernelci-local-snapshot-deadbeef",
        "definition_uri": null,
        "defconfig": "defconfig",
        "defconfig_full": "defconfig",
        "image_type": null,
        "lab_name": "fake-non-lava",
        "index": 999,
        "job_id": null,
        "endian": null,
        "test_cases": [],
        "time": 1.0,
        "log": "Fake LOG\nJust some text\nNo parsing"
    } 
EOF

```

- Test group document without subgroups, with test cases
```
curl -X POST  http://kernelci:5001/test \
    -H 'Content-Type: application/json' \
    -H 'Authorization: KERNELCI_API_TOKEN' \
    -d @- <<'EOF'
     {
        "sub_groups": [],
        "board": "fake-board",
        "build_environment": "gcc-8",
        "name": "Fake-test-group-with-test-cases",
        "metadata": {},
        "initrd_info": null,
        "git_branch": "fake-branch",
        "git_commit": "feeddeadbeef",
        "version": "1.0",
        "mach": null,
        "board_instance": null,
        "job": "fake-job",
        "file_server_resource": null,
        "initrd": null,
        "device_type": "fake-device-type",
        "arch": "fake-arm64",
        "kernel" : "kernelci-local-snapshot-deadbeef",
        "definition_uri": null,
        "defconfig": "defconfig",
        "defconfig_full": "defconfig",
        "image_type": null,
        "lab_name": "fake-non-lava",
        "index": 999,
        "job_id": null,
        "endian": null,
        "test_cases": [{"name": "FAKE_VIDIOC_QUERYCAP", 
                        "time": 1.0, 
                        "samples_sum": null,
                        "maximum": null,
                        "samples": null,
                        "attachments": [],
                        "minimum": null,
                        "vcs_commit": null,
                        "test_group_name": null,
                        "kvm_guest": null,
                        "version": "1.1",
                        "definition_uri": null,
                        "measurements": [],
                        "metadata": null,
                        "parameters": {},
                        "samples_sqr_sum": null,
                        "status": "PASS"}, 
                        {"name": "FAKE_MC-information-see-Media-Driver-Info-above",
                         "time": 1.0,
                         "samples_sum": null,
                         "maximum": null,
                         "samples": null,
                         "attachments": [],
                         "minimum": null,
                         "vcs_commit": null,
                         "test_group_name": null,
                         "kvm_guest": null,
                         "version": "1.1",
                         "definition_uri": null,
                         "measurements": [],
                         "metadata": null,
                         "parameters": {},
                         "samples_sqr_sum": null,
                         "status": "PASS"}, 
                         {"name": "USERPTR-select",
                          "time": 1.0,
                          "samples_sum": null,
                          "maximum": null,
                          "samples": null,
                          "attachments": [],
                          "minimum": null,
                          "vcs_commit": null,
                          "test_group_name": null,
                          "kvm_guest": null,
                          "version": "1.1", 
                          "definition_uri": null,
                          "measurements": [],
                          "metadata": null,
                          "parameters": {},
                          "samples_sqr_sum": null,
                          "status": "FAIL"}],
        "time": 1.0,
        "log": "Fake LOG\nJust some text\nNo parsing"
    } 
EOF
```
 

TODO:
[x] Prepare the new test_group handler
[x] Remove irrelevant unittests
[x] fix unittests