### PR TITLE
utils/report/bisect: add line about using Reported-by

### DIFF
--- a/app/utils/report/templates/bisect.txt
+++ b/app/utils/report/templates/bisect.txt
@@ -3,6 +3,10 @@
 * that you may be involved with the breaking commit it has      *
 * found.  No manual investigation has been done to verify it,   *
 * and the root cause of the problem may be somewhere else.      *
+*                                                               *
+* If you do send a fix, please include this trailer:            *
+*   Reported-by: "kernelci.org bot" <bot@kernelci.org>          *
+*                                                               *
 * Hope this helps!                                              *
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 


### PR DESCRIPTION
Add a line to ask people to use Reported-by kernelci.org bot in their
patches when fixing a problem reported by a KernelCI bisection.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>