### PR TITLE
T15051 Fix suite name fixup in lava callbacks

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -575,7 +575,7 @@ def add_tests(job_data, job_meta, lab_name, db_options,
             if suite_name != "lava":
                 # LAVA adds a prefix index to the test suite names "X_" except
                 # for the lava key.  Remove it to get the original name.
-                suite_name = suite_name.split("_")[1]
+                suite_name = suite_name.partition("_")[2]
             elif plan_name != "boot":
                 continue
             group = dict(meta)


### PR DESCRIPTION
Fix how the LAVA suite name mangling gets converted to drop the number
prefix.  The problem was when a suite name contained '_' it would also
get split and only the first part of the name would be kept,
i.e. "0_foo_bar" test suite name would become "foo" rather than
"foo_bar".  Using str.partition() fixes this problem.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>