### PR TITLE
Make a copy of the v4l2-compliance.txt

### DIFF
--- a/app/utils/report/templates/v4l2-compliance.txt
+++ b/app/utils/report/templates/v4l2-compliance.txt
@@ -1,0 +1,13 @@
+{% extends 'test.txt' %}
+
+{% block plan_description %}
+V4L2 Compliance on the {{ driver_name }} driver.
+
+This test ran "v4l2-compliance -s" from v4l-utils:
+
+    https://www.linuxtv.org/wiki/index.php/V4l2-utils
+
+See each detailed section in the report below to find out the git URL and
+particular revision that was used to build the test binaries.
+
+{% endblock %}


### PR DESCRIPTION
This patches adds a copy of v4l2-compliance.txt template in the templates
directory to test the a new 'test_template' object in the POST/send API.

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>