### PR TITLE
Remove tha hard-coded part of the v4l2-compliance plan

### DIFF
--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -54,24 +54,6 @@ TEST_REPORT_FIELDS = [
     models.VERSION_KEY,
 ]
 
-# FIXME: get this from test-configs.yaml
-TEST_PLAN_OPTIONS = {
-    "v4l2-compliance-uvc": {
-        "subject": "v4l2-compliance on uvcvideo",
-        "template": "plans/v4l2-compliance.txt",
-        "params": {
-            "driver_name": "uvcvideo",
-        },
-    },
-    "v4l2-compliance-vivid": {
-        "subject": "v4l2-compliance on vivid",
-        "template": "plans/v4l2-compliance.txt",
-        "params": {
-            "driver_name": "vivid",
-        },
-    },
-}
-
 
 def _regression_message(data):
     last_pass = data[0]
@@ -163,7 +145,6 @@ def create_test_report(data, email_format, db_options,
         models.PLAN_KEY,
     ])
 
-    plan_options = TEST_PLAN_OPTIONS.get(plan, {})
 
     spec = {x: y for x, y in data.iteritems() if x != models.PLAN_KEY}
     group_spec = dict(spec)
@@ -196,9 +177,8 @@ def create_test_report(data, email_format, db_options,
     tests_total = sum(group["total_tests"] for group in groups)
     regr_total = sum(group["regressions"] for group in groups)
 
-    plan_subject = plan_options.get("subject", plan)
-    subject_str = "{}/{} {}: {} tests, {} regressions ({})".format(
-        job, branch, plan_subject, tests_total, regr_total, kernel)
+    subject_str = "{}/{}: {} tests, {} regressions ({})".format(
+        job, branch, tests_total, regr_total, kernel)
 
     git_url, git_commit = (groups[0][k] for k in [
         models.GIT_URL_KEY, models.GIT_COMMIT_KEY])


### PR DESCRIPTION
In order to test the new 'test_template' object in the POST/send API,
this patch removes the hard-coded part to use the v4l2-compliance
template.

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>