### PR TITLE
Add lupa to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+lupa
 mock>0.7.2
 mongomock==2.0.0
 fakeredis


### PR DESCRIPTION
The lupa Python package is now required to use recent versions of
fakeredis.  This issue appeared with Debian Buster, running fakeredis
version 1.0.3.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>