### PR TITLE
LAVA callback: fix rootfs URL check

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -510,7 +510,10 @@ def _add_rootfs_info(group, base_path, file_name="build_info.json"):
         return
 
     try:
-        if rootfs_url.startswith(DEFAULT_STORAGE_URL):
+        # compare to default URL without the scheme
+        _default_url = urllib2.urlparse.urlparse(DEFAULT_STORAGE_URL).netloc
+        _rootfs_url = urllib2.urlparse.urlparse(rootfs_url).netloc
+        if _rootfs_url.startswith(_default_url):
             rootfs_url_path = urllib2.urlparse.urlparse(rootfs_url).path
             rootfs_rel_dir = os.path.dirname(rootfs_url_path).lstrip("/")
             json_file = os.path.join(base_path, rootfs_rel_dir, file_name)


### PR DESCRIPTION
When looking for the `build_info.json` file associated with a rootfs
image, the backend checks if the file exists locally, if not it tries
to fetch from a URL.

The check to detect local file looks at DEFAULT_STORAGE_URL which is
an https URL for storage.kernelci.org.  However, if a job was
submitted using an http URL for the storage server, the
build_info.json will have been stored locally, but the check will fail
due to http vs https.

To fix, strip the URL scheme before comparing.

Reported-by: Kholoud Touil <ktouil@baylibre.com>
Signed-off-by: Kevin Hilman <khilman@baylibre.com>