### PR TITLE
T16555 Add login test case in LAVA callback handler

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -429,6 +429,22 @@ def _parse_lava_test_data(test_case, test_meta):
         test_case[models.NAME_KEY] = "-".join(extra_name)
 
 
+def _add_login_case(cases, suite_results, name):
+    tests = yaml.load(suite_results, Loader=yaml.CLoader)
+    tests_by_name = {t['name']: t for t in tests}
+    login = tests_by_name.get(name)
+    if not login:
+        return
+    test_case = {
+        models.VERSION_KEY: "1.1",
+        models.TIME_KEY: "0.0",
+        models.INDEX_KEY: len(cases) + 1,
+        models.NAME_KEY: "login",
+        models.STATUS_KEY: login["result"],
+    }
+    cases.append(test_case)
+
+
 def _add_test_results(group, suite_results, suite_name):
     """Add test results from test suite data to a group.
 
@@ -591,30 +607,36 @@ def add_tests(job_data, job_meta, lab_name, db_options,
         _add_rootfs_info(meta, base_path)
         _store_lava_json(job_data, meta)
         groups = []
+        cases = []
 
         for suite_name, suite_results in job_data["results"].iteritems():
-            if suite_name != "lava":
-                # LAVA adds a prefix index to the test suite names "X_" except
-                # for the lava key.  Remove it to get the original name.
+            if suite_name == "lava":
+                _add_login_case(cases, suite_results, 'auto-login-action')
+            else:
                 suite_name = suite_name.partition("_")[2]
-            elif plan_name != "boot":
-                continue
-            group = dict(meta)
-            group[models.NAME_KEY] = suite_name
-            _add_test_results(group, suite_results, suite_name)
-            groups.append(group)
+                group = dict(meta)
+                group[models.NAME_KEY] = suite_name
+                _add_test_results(group, suite_results, suite_name)
+                groups.append(group)
 
         if (len(groups) == 1) and (groups[0][models.NAME_KEY] == plan_name):
             # Only one group with same name as test plan
             plan = groups[0]
-        elif groups:
+            if cases:
+                insert_len = len(cases)
+                plan_cases = plan[models.TEST_CASES_KEY]
+                for case in plan_cases:
+                    case[models.INDEX_KEY] += insert_len
+                cases.extend(plan_cases)
+                plan[models.TEST_CASES_KEY] = cases
+        elif groups or cases:
             # Create top-level group with the test plan name
             plan = dict(meta)
             plan[models.NAME_KEY] = plan_name
             for index, group in enumerate(groups):
                 group[models.INDEX_KEY] = index
             plan[models.SUB_GROUPS_KEY] = groups
-            plan[models.TEST_CASES_KEY] = []
+            plan[models.TEST_CASES_KEY] = cases
 
         if plan:
             ret_code, plan_doc_id, err = \


### PR DESCRIPTION
When parsing the LAVA callback data, add a "login" test case in the
top-level group based on the result of "auto-login-action" by default.
This is to catch early boot problems as in the legacy boot test plan,
before any test could be run.  Note that the "login" test case result
itself is not LAVA-specific, but only where it got its status from in
this implementation.

As part of this change, stop parsing the rest of the "lava" test
results for the "boot" test plan as this is not useful any more.