### PR TITLE
T16584 Create test report summary with dynamic column widths

### DIFF
--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -3,18 +3,9 @@
 Test results summary
 --------------------
 
-run | platform                 | arch   | lab                      | compiler | defconfig          | errors
-----+--------------------------+--------+--------------------------+----------+--------------------+-------
+{{ summary_headers }}
 {%- for group in test_groups %}
-{{ "%3d | %-24s | %-6s | %-24s | %-8s | %-18s | %d/%d"|format(
-   loop.index,
-   group.board,
-   group.arch,
-   group.lab_name,
-   group.build_environment,
-   group.defconfig,
-   group.total_results.FAIL,
-   group.total_tests) }}
+{{ group.summary }}
 {%- endfor %}
 
 {% block plan_description %}
@@ -43,17 +34,8 @@ Test Failures
 {% for group in test_groups %} {# test_groups #}
   {%- if group.total_results.FAIL %} {# group fail #}
 
-run | platform                 | arch   | lab                      | compiler | defconfig          | errors
-----+--------------------------+--------+--------------------------+----------+--------------------+-------
-{{ "%3d | %-24s | %-6s | %-24s | %-8s | %-18s | %d/%d"|format(
-    loop.index,
-    group.board,
-    group.arch,
-    group.lab_name,
-    group.build_environment,
-    group.defconfig,
-    group.total_results.FAIL,
-    group.total_tests) }}
+{{ summary_headers }}
+{{ group.summary }}
 
   Results:     {{ group.total_results.PASS }} PASS, {{ group.total_results.FAIL }} FAIL, {{ group.total_results.SKIP }} SKIP
   Full config: {{ group.defconfig_full }}


### PR DESCRIPTION
The test report has some summary tables which can easily get distorted
with long values such as defconfigs with many extra options.  In other
cases, there are some short values but a lot of white space with fixed
widths.  So to solve these issues and make the table scale better,
compute the width of every column dynamically based on the values to
show and squash very long ones with "..." in the middle to not make
the table completely unusable.

Note that it has to be done in Python as it's too much logic for the
Jinja templates.  As a result, the summary tables are passed already
rendered to the template.  Doing this arguably makes the templates
easier to manage anyway, but if it causes some issues then maybe some
custom Jinja extension could be created for dynamic ASCII tables.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>