### PR TITLE
Use file_server_resource when posting build meta-data

### DIFF
--- a/app/handlers/tests/test_build_handler.py
+++ b/app/handlers/tests/test_build_handler.py
@@ -139,7 +139,8 @@ class TestBuildHandler(TestHandlerBase):
                 defconfig="defconfig",
                 arch="arch",
                 git_branch="branch",
-                build_environment="build_environment"
+                build_environment="build_environment",
+                file_server_resource="path/to/build/data"
             )
         )
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -601,6 +601,7 @@ BUILD_VALID_KEYS = {
             ARCHITECTURE_KEY,
             BUILD_ENVIRONMENT_KEY,
             DEFCONFIG_KEY,
+            FILE_SERVER_RESOURCE_KEY,
             GIT_BRANCH_KEY,
             JOB_KEY,
             KERNEL_KEY
@@ -610,6 +611,7 @@ BUILD_VALID_KEYS = {
             BUILD_ENVIRONMENT_KEY,
             DEFCONFIG_FULL_KEY,
             DEFCONFIG_KEY,
+            FILE_SERVER_RESOURCE_KEY,
             GIT_BRANCH_KEY,
             JOB_KEY,
             KERNEL_KEY,

--- a/app/utils/build/__init__.py
+++ b/app/utils/build/__init__.py
@@ -524,12 +524,8 @@ def import_single_build(json_obj, db_options, base_path=utils.BASE_PATH):
     git_branch = utils.clean_branch_name(git_branch)
 
     if (utils.valid_name(job) and utils.valid_name(kernel)):
-        # New directory structure:
-        # $job/$branch/$kernel/$arch/$defconfig/$environment
-
-        parent_dir = os.path.join(base_path, job, git_branch, kernel, arch)
-        build_dir = os.path.join(
-            parent_dir, defconfig_full or defconfig, build_environment)
+        file_server_resource = j_get(models.FILE_SERVER_RESOURCE_KEY)
+        build_dir = os.path.join(base_path, file_server_resource)
 
         if os.path.isdir(build_dir):
             try:

--- a/app/utils/build/tests/test_build_import.py
+++ b/app/utils/build/tests/test_build_import.py
@@ -506,7 +506,8 @@ class TestBuildUtils(unittest.TestCase):
             "defconfig": "defconfig",
             "arch": "arch",
             "git_branch": "branch",
-            "build_environment": "build_environment"
+            "build_environment": "build_environment",
+            "file_server_resource": "path/to/build/data",
         }
         build_id, job_id, errors = utils.build.import_single_build(
             json_obj, {})
@@ -548,7 +549,8 @@ class TestBuildUtils(unittest.TestCase):
             "defconfig": "defconfig",
             "git_branch": "branch",
             "arch": "arch",
-            "build_environment": "build_environment"
+            "build_environment": "build_environment",
+            "file_server_resource": "path/to/build/data",
         }
         build_id, job_id, errors = utils.build.import_single_build(
             json_obj, {})

--- a/app/utils/log_parser.py
+++ b/app/utils/log_parser.py
@@ -594,15 +594,8 @@ def parse_single_build_log(
     if json_obj:
         build_doc = mbuild.BuildDocument.from_json(json_obj)
         if build_doc:
-            build_dir = os.path.join(
-                base_path,
-                build_doc.job,
-                build_doc.git_branch,
-                build_doc.kernel,
-                build_doc.arch,
-                build_doc.defconfig_full,
-                build_doc.build_environment)
-
+            file_server_resource = build_doc.file_server_resource
+            build_dir = os.path.join(base_path, file_server_resource)
             log_file = os.path.join(build_dir, build_log)
             status, err_lines, warn_lines, mism_lines = _parse_log(
                 build_doc, log_file, build_dir, errors)

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -40,8 +40,8 @@ Test Failures
   Results:     {{ group.total_results.PASS }} PASS, {{ group.total_results.FAIL }} FAIL, {{ group.total_results.SKIP }} SKIP
   Full config: {{ group.defconfig_full }}
   Compiler:    {{ group.build_environment }}{% if group.compiler_version_full %} ({{ group.compiler_version_full }}){% endif %}
-  Plain log:   {{ storage_url }}/{{ group.job }}/{{ group.git_branch }}/{{ group.kernel }}/{{ group.arch }}/{{ group.defconfig_full }}/{{ group.build_environment }}/{{ group.lab_name }}/{{ group.boot_log }}
-  HTML log:    {{ storage_url }}/{{ group.job }}/{{ group.git_branch }}/{{ group.kernel }}/{{ group.arch }}/{{ group.defconfig_full }}/{{ group.build_environment }}/{{ group.lab_name }}/{{ group.boot_log_html }}
+  Plain log:   {{ storage_url }}/{{ group.file_server_resource }}/{{ group.lab_name }}/{{ group.boot_log }}
+  HTML log:    {{ storage_url }}/{{ group.file_server_resource }}/{{ group.lab_name }}/{{ group.boot_log_html }}
     {%- if group.initrd %}
   Rootfs:      {{ group.initrd }}
     {%- endif %}

--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -45,6 +45,7 @@ TEST_REPORT_FIELDS = [
     models.DEFCONFIG_KEY,
     models.DEFINITION_URI_KEY,
     models.DEVICE_TYPE_KEY,
+    models.FILE_SERVER_RESOURCE_KEY,
     models.GIT_BRANCH_KEY,
     models.GIT_COMMIT_KEY,
     models.GIT_DESCRIBE_KEY,


### PR DESCRIPTION
Accept the file_server_resource in build POST requests and use it to
determine the location of the build binaries.  This relies on the
client using the same path when pushing the build binaries and then
sending the meta-data, without having the backend to independently
reconstruct the path (and get it wrong in some cases).

This should also help solving issues such as branch names with a slash
or defconfigs with a path to a config fragment.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>