### PR TITLE
check if message is a array and join it in one string

### DIFF
--- a/app/utils/lava_log_parser.py
+++ b/app/utils/lava_log_parser.py
@@ -85,6 +85,9 @@ def run(log, boot, txt, html):
         raw_ts = DT_RE.match(dt).groups()[1]
         timestamp = "<span class=\"timestamp\">{}  </span>".format(raw_ts)
 
+        if isinstance(msg, list):
+            msg = ' '.join(msg)  
+
         fmt = formats.get(level)
         if fmt:
             log_buffer.append(timestamp + fmt.format(cgi.escape(msg)))


### PR DESCRIPTION
There someting new on the LAVA log that sends as response an
array as message in cases that happen timed out login,
so to handle with this case we are joining all message
that was splited in an array to one string.

Signed-off-by: Alex P <alexandra.pereira@collabora.com>