### PR TITLE
T16501 test measurements

### DIFF
--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -69,7 +69,13 @@ Test Failures
   {{ sg.name }} - {{ sg.test_cases|length }} tests: {{ sg.results.PASS }}  PASS, {{ sg.results.FAIL }} FAIL, {{ sg.results.SKIP }} SKIP
         {%- for tc in sg.test_cases %}
           {%- if 'FAIL' == tc.status %}
-    * {{ tc.name }}: {{ tc.failure_message }}
+    * {{ tc.name }}:
+        {{ tc.failure_message }}
+            {%- if tc.measurements %}
+              {%- for measurement in tc.measurements %}
+        {{measurement.value}} {{measurement.unit}}
+              {%- endfor -%}
+            {% endif %}
           {%- endif %}
         {%- endfor %}
       {%- endif %} {# sg fail #}

--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -98,6 +98,11 @@ def _add_test_group_data(group, db, spec, hierarchy=[]):
     test_cases = []
     for test_case_id in group[models.TEST_CASES_KEY]:
         test_case = utils.db.find_one2(case_collection, test_case_id)
+        measurements = test_case[models.MEASUREMENTS_KEY]
+        for measurement in measurements:
+            value = measurement['value']
+            if (value % 1.0) == 0:
+                measurement['value'] = int(value)
         if test_case[models.STATUS_KEY] == "FAIL":
             regr_spec[models.HIERARCHY_KEY] = (
                 hierarchy + [test_case[models.NAME_KEY]])


### PR DESCRIPTION
Show measurements in test reports.

This still only applies to test cases that failed, as other test cases aren't shown in the report.  Each measurement is shown on a separate line with its value and unit.

Measurements aren't used in the backend to determine whether a test case passed or failed, this is decided on the client side.