### PR TITLE
Rename /etc/linaro to /etc/kernelci

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,9 +5,9 @@ All installation docs are now on the dedicated [kernelci-backend-config](https:/
 # Configuration/Administration
 
 ## Main configurations files
-/etc/linaro/kernelci-frontend.cfg
-/etc/linaro/kernelci-backend.cfg
-/etc/linaro/kernelci-celery.cfg
+/etc/kernelci/kernelci-frontend.cfg
+/etc/kernelci/kernelci-backend.cfg
+/etc/kernelci/kernelci-celery.cfg
 
 They are filled with informations from secrets.yml.
 

--- a/app/server.py
+++ b/app/server.py
@@ -37,7 +37,7 @@ import utils.database.redisdb as redisdb
 import utils.db
 
 
-DEFAULT_CONFIG_FILE = "/etc/linaro/kernelci-backend.cfg"
+DEFAULT_CONFIG_FILE = "/etc/kernelci/kernelci-backend.cfg"
 
 topt.define(
     "master_key", default=str(uuid.uuid4()), type=str, help="The master key")

--- a/app/taskqueue/celery.py
+++ b/app/taskqueue/celery.py
@@ -33,7 +33,7 @@ import taskqueue.celeryconfig as celeryconfig
 import taskqueue.serializer as serializer
 
 
-CELERY_CONFIG_FILE = "/etc/linaro/kernelci-celery.cfg"
+CELERY_CONFIG_FILE = "/etc/kernelci/kernelci-celery.cfg"
 TASKS_LIST = [
     "taskqueue.tasks.bisect",
     "taskqueue.tasks.boot",

--- a/app/utils/report/common.py
+++ b/app/utils/report/common.py
@@ -65,7 +65,7 @@ BOOT_REGRESSIONS_URL = BOOT_SUMMARY_URL + u"#regressions"
 BUILD_SUMMARY_URL = \
     u"{build_url:s}/{job:s}/branch/{git_branch:s}/kernel/{kernel:s}/"
 
-DEFAULT_CONFIG_FILE = "/etc/linaro/kernelci-backend.cfg"
+DEFAULT_CONFIG_FILE = "/etc/kernelci/kernelci-backend.cfg"
 
 if os.path.isfile(DEFAULT_CONFIG_FILE):
     with open(DEFAULT_CONFIG_FILE, 'r') as infile:


### PR DESCRIPTION
The kernelci-backend settings files should really be stoed in
/etc/kernelci by default rather than /etc/linaro.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>