### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+dist: xenial
+
+language: python
+
+python:
+  - "2.7"
+
+install:
+  - pip install -r requirements.txt
+  - pip install -r requirements-dev.txt
+  - pip install pycodestyle
+
+script:
+  - cd app
+  - >
+    for dir in
+    models/tests
+    utils/tests
+    utils/build/tests
+    utils/bisect/tests
+    utils/report/tests
+    handlers/common/tests;
+    do
+      echo Running tests in $dir
+      python -m unittest discover $dir || exit 1
+    done
+  - pycodestyle .


### PR DESCRIPTION
Add basic Travis CI definition to run existing unit tests that don't
rely on an actual redis service running, and pep8 checks.
    
Other unit tests, in particular the kci_test ones, are important to
enable in CI but they need to be modified to use fakeredis first and
drop other runtime requirements so they can also run in Travis CI.
