### PR TITLE
T17213 Add plan_variant key

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -161,6 +161,7 @@ NOT_FIELD_KEY = "nfield"
 PARAMETERS_KEY = "parameters"
 PARENT_ID_KEY = "parent_id"
 PLAN_KEY = "plan"
+PLAN_VARIANT_KEY = "plan_variant"
 PRIVATE_KEY = "private"
 PROPERTIES_KEY = "properties"
 QEMU_COMMAND_KEY = "qemu_command"
@@ -1186,6 +1187,7 @@ LAVA_CALLBACK_VALID_METADATA_KEYS = {
             "platform.dtb_short",
             "platform.fastboot",
             "platform.mach",
+            "test.plan_variant",
         ],
     },
 }

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1151,6 +1151,7 @@ LAVA_CALLBACK_VALID_METADATA_KEYS = {
             "platform.fastboot",
             "platform.mach",
             "test.plan",
+            "test.plan_variant",
         ],
     },
     "test": {

--- a/app/models/bisect.py
+++ b/app/models/bisect.py
@@ -60,6 +60,8 @@ class BisectDocument(modb.BaseDocument):
         self.compiler_version = None
         self.build_environment = None
         self.build_id = None
+        self.plan = None
+        self.plan_variant = None
 
     @property
     def collection(self):
@@ -141,6 +143,8 @@ class BisectDocument(modb.BaseDocument):
             models.COMPILER_VERSION_KEY: self.compiler_version,
             models.BUILD_ENVIRONMENT_KEY: self.build_environment,
             models.BUILD_ID_KEY: self.build_id,
+            models.PLAN_KEY: self.plan,
+            models.PLAN_VARIANT_KEY: self.plan_variant,
         }
 
         if self.id:

--- a/app/models/boot.py
+++ b/app/models/boot.py
@@ -118,6 +118,8 @@ class BootDocument(modb.BaseDocument):
         self.load_addr = None
         self.mach = None
         self.metadata = {}
+        self.plan = None
+        self.plan_variant = None
         self.qemu = None
         self.qemu_command = None
         self.retries = 0
@@ -218,6 +220,8 @@ class BootDocument(modb.BaseDocument):
             models.LOAD_ADDR_KEY: self.load_addr,
             models.MACH_KEY: self.mach,
             models.METADATA_KEY: self.metadata,
+            models.PLAN_KEY: self.plan,
+            models.PLAN_VARIANT_KEY: self.plan_variant,
             models.QEMU_COMMAND_KEY: self.qemu_command,
             models.QEMU_KEY: self.qemu,
             models.RETRIES_KEY: self.retries,

--- a/app/models/test_group.py
+++ b/app/models/test_group.py
@@ -90,6 +90,7 @@ class TestGroupDocument(modb.BaseDocument):
         self.load_addr = None
         self.mach = None
         self.metadata = {}
+        self.plan_variant = None
         self.qemu = None
         self.qemu_command = None
         self.retries = 0
@@ -208,6 +209,7 @@ class TestGroupDocument(modb.BaseDocument):
             models.QEMU_COMMAND_KEY: self.qemu_command,
             models.RETRIES_KEY: self.retries,
             models.NAME_KEY: self.name,
+            models.PLAN_VARIANT_KEY: self.plan_variant,
             models.TEST_CASES_KEY: self.test_cases,
             models.PARENT_ID_KEY: self.parent_id,
             models.SUB_GROUPS_KEY: self.sub_groups,

--- a/app/models/tests/test_bisect_model.py
+++ b/app/models/tests/test_bisect_model.py
@@ -83,6 +83,8 @@ class TestBisectModel(unittest.TestCase):
             "build_environment": None,
             "git_branch": None,
             "git_url": None,
+            "plan": None,
+            "plan_variant": None,
         }
         self.assertDictEqual(expected, bisect_doc.to_dict())
 
@@ -120,6 +122,8 @@ class TestBisectModel(unittest.TestCase):
             "build_environment": None,
             "git_branch": None,
             "git_url": None,
+            "plan": None,
+            "plan_variant": None,
         }
         self.assertDictEqual(expected, bisect_doc.to_dict())
 
@@ -137,6 +141,7 @@ class TestBisectModel(unittest.TestCase):
         bisect_doc.log = "https://storage.org/log.txt"
         bisect_doc.device_type = "qemu"
         bisect_doc.lab_name = "secret-lab"
+        bisect_doc.plan = "cunning"
 
         expected = {
             "_id": "bar",
@@ -172,6 +177,8 @@ class TestBisectModel(unittest.TestCase):
             "log": "https://storage.org/log.txt",
             "found_summary": None,
             "checks": {},
+            "plan": "cunning",
+            "plan_variant": None,
         }
         self.assertDictEqual(expected, bisect_doc.to_dict())
 
@@ -229,6 +236,8 @@ class TestBisectModel(unittest.TestCase):
         bisect_doc.compiler = "randomcc"
         bisect_doc.compiler_version = "123.456"
         bisect_doc.build_environment = "build-env"
+        bisect_doc.plan = "cunning"
+        bisect_doc.plan_variant = "similar"
 
         expected = {
             "_id": "bar",
@@ -260,6 +269,8 @@ class TestBisectModel(unittest.TestCase):
             "kernel": "v4.56",
             "log": None,
             "checks": {},
+            "plan": "cunning",
+            "plan_variant": "similar",
         }
 
         self.assertDictEqual(expected, bisect_doc.to_dict())

--- a/app/models/tests/test_boot_model.py
+++ b/app/models/tests/test_boot_model.py
@@ -61,6 +61,8 @@ class TestBootModel(unittest.TestCase):
         boot_doc.uimage_addr = "uimage_addr"
         boot_doc.qemu = "qemu_binary"
         boot_doc.qemu_command = "qemu_command"
+        boot_doc.plan = "boot"
+        boot_doc.plan_variant = "welly"
         boot_doc.metadata = {"foo": "bar"}
         boot_doc.mach = "soc"
         boot_doc.lab_name = "lab-name"
@@ -115,6 +117,8 @@ class TestBootModel(unittest.TestCase):
             "metadata": {"foo": "bar"},
             "qemu": "qemu_binary",
             "qemu_command": "qemu_command",
+            "plan": "boot",
+            "plan_variant": "welly",
             "retries": 10,
             "status": None,
             "time": 0,
@@ -193,6 +197,8 @@ class TestBootModel(unittest.TestCase):
             "metadata": {"foo": "bar"},
             "qemu": "qemu_binary",
             "qemu_command": "qemu_command",
+            "plan": "boot",
+            "plan_variant": "welly",
             "retries": 10,
             "status": "PASS",
             "time": 0,

--- a/app/models/tests/test_test_group_model.py
+++ b/app/models/tests/test_test_group_model.py
@@ -76,6 +76,7 @@ class TestTestGroupModel(unittest.TestCase):
         test_group.mach = "mach"
         test_group.metadata = {"foo": "bar"}
         test_group.parent_id = "parent-id"
+        test_group.plan_variant = "tother"
         test_group.qemu = "qemu"
         test_group.qemu_command = "qemu-command"
         test_group.retries = 2
@@ -129,6 +130,7 @@ class TestTestGroupModel(unittest.TestCase):
             "mach": "mach",
             "metadata": {"foo": "bar"},
             "parent_id": "parent-id",
+            "plan_variant": "tother",
             "name": "name",
             "qemu": "qemu",
             "qemu_command": "qemu-command",
@@ -156,6 +158,7 @@ class TestTestGroupModel(unittest.TestCase):
         self.assertIsNone(mtgroup.TestGroupDocument.from_json(""))
 
     def test_group_doc_from_json(self):
+        self.maxDiff = None
         group_json = {
             "_id": "id",
             "arch": "arm",
@@ -200,6 +203,7 @@ class TestTestGroupModel(unittest.TestCase):
             "metadata": {"foo": "bar"},
             "name": "name",
             "parent_id": "parent-id",
+            "plan_variant": "tother",
             "qemu": None,
             "qemu_command": None,
             "retries": 0,

--- a/app/utils/bisect/boot.py
+++ b/app/utils/bisect/boot.py
@@ -347,6 +347,8 @@ def create_boot_bisect(good, bad, db_options):
     doc.kernel = bad[models.KERNEL_KEY]
     doc.git_branch = bad[models.GIT_BRANCH_KEY]
     doc.git_url = bad[models.GIT_URL_KEY]
+    doc.plan = bad[models.PLAN_KEY]
+    doc.plan_variant = bad[models.PLAN_VARIANT_KEY]
     doc.arch = bad[models.ARCHITECTURE_KEY]
     doc.defconfig = bad[models.DEFCONFIG_KEY]
     doc.defconfig_full = bad[models.DEFCONFIG_FULL_KEY]

--- a/app/utils/boot/__init__.py
+++ b/app/utils/boot/__init__.py
@@ -269,6 +269,8 @@ def _update_boot_doc_from_json(boot_doc, boot_dict, errors):
     boot_doc.metadata = boot_dict.get(models.METADATA_KEY, {})
     boot_doc.qemu = boot_dict.get(models.QEMU_KEY, None)
     boot_doc.qemu_command = boot_dict.get(models.QEMU_COMMAND_KEY, None)
+    boot_doc.plan = boot_dict.get(models.PLAN_KEY, None)
+    boot_doc.plan_variant = boot_dict.get(models.PLAN_VARIANT_KEY, None)
     boot_doc.retries = boot_dict.get(models.BOOT_RETRIES_KEY, 0)
     boot_doc.uimage = boot_dict.get(models.UIMAGE_KEY, None)
     boot_doc.uimage_addr = boot_dict.get(models.UIMAGE_ADDR_KEY, None)

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -90,6 +90,7 @@ META_DATA_MAP_TEST = {
     models.VCS_COMMIT_KEY: "git.commit",
     models.IMAGE_TYPE_KEY: "image.type",
     models.PLAN_KEY: "test.plan",
+    models.PLAN_VARIANT_KEY: "test.plan_variant",
     models.BUILD_ENVIRONMENT_KEY: "job.build_environment",
     models.FILE_SERVER_RESOURCE_KEY: "job.file_server_resource",
 }

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -113,6 +113,8 @@ META_DATA_MAP_BOOT = {
     models.INITRD_KEY: "job.initrd_url",
     models.BOARD_KEY: "platform.name",
     models.DEVICE_TYPE_KEY: "device.type",
+    models.PLAN_KEY: "test.plan",
+    models.PLAN_VARIANT_KEY: "test.plan_variant",
     models.BUILD_ENVIRONMENT_KEY: "job.build_environment",
     models.FILE_SERVER_RESOURCE_KEY: "job.file_server_resource",
 }

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -394,6 +394,7 @@ def _update_test_group_doc_from_json(group_doc, test_dict, errors):
         models.KERNEL_IMAGE_SIZE_KEY, None)
     group_doc.load_addr = test_dict.get(models.BOOT_LOAD_ADDR_KEY, None)
     group_doc.metadata = test_dict.get(models.METADATA_KEY, {})
+    group_doc.plan_variant = test_dict.get(models.PLAN_VARIANT_KEY)
     group_doc.qemu = test_dict.get(models.QEMU_KEY, None)
     group_doc.qemu_command = test_dict.get(models.QEMU_COMMAND_KEY, None)
     group_doc.retries = test_dict.get(models.BOOT_RETRIES_KEY, 0)

--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -507,6 +507,8 @@ def _start_bisection(bisection, jopts):
         "CC": models.COMPILER_KEY,
         "CC_VERSION": models.COMPILER_VERSION_KEY,
         "BUILD_ENVIRONMENT": models.BUILD_ENVIRONMENT_KEY,
+        "TEST_PLAN": models.PLAN_KEY,
+        "TEST_PLAN_VARIANT": models.PLAN_VARIANT_KEY,
     }
     params = {
         k: v for (k, v) in (


### PR DESCRIPTION
This is to add the plan_variant meta-data key and use it in test_group, boot and bisection documents.  The definition of a test plan variant is to know which exact test configuration was used from test-configs.yaml, for example the "baseline" test plan actually uses "baseline_qemu" on QEMU devices.  All the variants of a test plan have their results dealt with in the same way, but have parameters to cover different platforms or combinations within that space.

In particular, this enables bisections to reproduce the test jobs with the same test configuration as used for the original tests that failed and caused a regression.  It's needed to be able to use `kci_test` in the automated bisection jobs (`bisect.jpl` in kernelci-core).