### PR TITLE
Use Unicode for HTML format strings in lava_log_parser.py

### DIFF
--- a/app/utils/lava_log_parser.py
+++ b/app/utils/lava_log_parser.py
@@ -77,25 +77,25 @@ def run(log, boot, txt, html):
         boot_result_html = "<span class=\"warn\">{}</span>".format(boot_result)
 
     formats = {
-        "emerg": "<span class=\"alert\">{}</span>\n",
-        "alert": "<span class=\"alert\">{}</span>\n",
-        "crit": "<span class=\"alert\">{}</span>\n",
-        "error": "<span class=\"err\">{}</span>\n",
-        "warning": "<span class=\"warn\">{}</span>\n",
-        "notice": "<span class=\"info\">{}</span>\n",
-        "info": "<span class=\"lavainfo\">{}</span>\n",
-        "debug": "<span class=\"lavainfo\">{}</span>\n"
+        "emerg": u"<span class=\"alert\">{}</span>\n",
+        "alert": u"<span class=\"alert\">{}</span>\n",
+        "crit": u"<span class=\"alert\">{}</span>\n",
+        "error": u"<span class=\"err\">{}</span>\n",
+        "warning": u"<span class=\"warn\">{}</span>\n",
+        "notice": u"<span class=\"info\">{}</span>\n",
+        "info": u"<span class=\"lavainfo\">{}</span>\n",
+        "debug": u"<span class=\"lavainfo\">{}</span>\n"
     }
 
     kernel_log_levels = {
-        "0": "<span class=\"alert\">{}</span>\n",
-        "1": "<span class=\"alert\">{}</span>\n",
-        "2": "<span class=\"alert\">{}</span>\n",
-        "3": "<span class=\"err\">{}</span>\n",
-        "4": "<span class=\"warn\">{}</span>\n",
-        "5": "<span class=\"info\">{}</span>\n",
-        "6": "<span class=\"info\">{}</span>\n",
-        "7": "<span class=\"debug\">{}</span>\n",
+        "0": u"<span class=\"alert\">{}</span>\n",
+        "1": u"<span class=\"alert\">{}</span>\n",
+        "2": u"<span class=\"alert\">{}</span>\n",
+        "3": u"<span class=\"err\">{}</span>\n",
+        "4": u"<span class=\"warn\">{}</span>\n",
+        "5": u"<span class=\"info\">{}</span>\n",
+        "6": u"<span class=\"info\">{}</span>\n",
+        "7": u"<span class=\"debug\">{}</span>\n",
     }
 
     numbers = {


### PR DESCRIPTION
Use Unicode for the HTML format strings so that Unicode log lines can
get decoded correctly, rather than failing with the `ascii` default
codec.

The error below was seen with this log line which contains a Unicode
"copyright" symbol:
```
<6>jffs2: version 2.2. (NAND) © 2001-2006 Red Hat, Inc.
```
```
[   ERROR/MainThread] 'ascii' codec can't encode character u'\xa9' in position 36: ordinal not in range(128)
Traceback (most recent call last):
  File "/home/gtucker/project/kernelci/kernelci-backend/app/utils/callback/lava.py", line 609, in add_tests
    _add_test_log(meta, job_data["log"], plan_name)
  File "/home/gtucker/project/kernelci/kernelci-backend/app/utils/callback/lava.py", line 309, in _add_test_log
    utils.lava_log_parser.run(log, meta, txt, html)
  File "/home/gtucker/project/kernelci/kernelci-backend/app/utils/lava_log_parser.py", line 150, in run
    log_buffer.append(timestamp + fmt.format(msg_escape))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa9' in position 36: ordinal not in range(128)
```