### PR TITLE
Use yaml.safe_load() in utils.report.test

### DIFF
--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -69,7 +69,7 @@ TEST_REPORT_FIELDS = [
 
 TEMPLATES_YAML = os.path.join(rcommon.TEMPLATES_DIR, "templates.yaml")
 with open(TEMPLATES_YAML) as templates_file:
-    TEMPLATES = yaml.load(templates_file)["templates"]
+    TEMPLATES = yaml.safe_load(templates_file)["templates"]
 
 
 def _regression_message(data):


### PR DESCRIPTION
Fix this warning by using safe_load instead:
```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated
```