### PR TITLE
Remove redundant key when updating test group document IDs

### DIFF
--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -436,7 +436,6 @@ def _update_test_group_doc_ids(group_doc, database):
         models.ARCHITECTURE_KEY: arch,
         models.DEFCONFIG_KEY: defconfig,
         models.JOB_KEY: job,
-        models.KERNEL_KEY: kernel,
         models.BUILD_ENVIRONMENT_KEY: build_env,
     })
 


### PR DESCRIPTION
The "kernel" key is already present in the initial spec to find the
job document so there's no need to update it again to search for a
build document.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>