### PR TITLE
app/handlers/callback: use yaml.safe_load

### DIFF
--- a/app/handlers/callback.py
+++ b/app/handlers/callback.py
@@ -168,7 +168,7 @@ class LavaCallbackHandler(CallbackHandler):
             json_obj, **kwargs)
         if not valid:
             return valid, errors
-        definition = yaml.load(json_obj["definition"], Loader=yaml.CLoader)
+        definition = yaml.safe_load(json_obj["definition"])
         job_meta = definition.get("metadata")
         if not job_meta:
             return False, "metadata missing from LAVA job definition"


### PR DESCRIPTION
When testing a fresh docker-based install using debian/buster and
python3, this YAML load triggers an error about the missing CLoader
as well as the unsafe load.  Fix it.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>