### PR TITLE
python3 rework: convert to except as

### DIFF
--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -269,7 +269,7 @@ class BaseHandler(tornado.web.RequestHandler):
                         response = hresponse.HandlerResponse(400)
                         response.reason = "Provided JSON is not valid"
                         response.errors = errors
-                except ValueError, ex:
+                except ValueError as ex:
                     self.log.exception(ex)
                     error = "No JSON data found in the POST request"
                     self.log.error(error)
@@ -402,7 +402,7 @@ class BaseHandler(tornado.web.RequestHandler):
             else:
                 response.status_code = 404
                 response.reason = "Resource '%s' not found" % doc_id
-        except bson.errors.InvalidId, ex:
+        except bson.errors.InvalidId as ex:
             self.log.exception(ex)
             self.log.error("Provided doc ID '%s' is not valid", doc_id)
             response.status_code = 400

--- a/app/handlers/bisect.py
+++ b/app/handlers/bisect.py
@@ -105,7 +105,7 @@ class BisectHandler(hbase.BaseHandler):
                     else:
                         response = hresponse.HandlerResponse(404)
                         response.reason = "Resource not found"
-                except bson.errors.InvalidId, ex:
+                except bson.errors.InvalidId as ex:
                     self.log.exception(ex)
                     self.log.error(
                         "Wrong ID '%s' value passed as object ID", doc_id)
@@ -224,7 +224,7 @@ class BisectHandler(hbase.BaseHandler):
                         "compare_to": s_get(models.COMPARE_TO_KEY, None)}
                     response = bisect_func(
                         doc_id, self.settings["dboptions"], **kwargs)
-            except bson.errors.InvalidId, ex:
+            except bson.errors.InvalidId as ex:
                 self.log.exception(ex)
                 self.log.error(
                     "Wrong ID '%s' value passed as object ID", doc_id)

--- a/app/handlers/boot.py
+++ b/app/handlers/boot.py
@@ -144,7 +144,7 @@ class BootHandler(hbase.BaseHandler):
                     else:
                         response = hresponse.HandlerResponse(404)
                         response.reason = "Resource '%s' not found" % doc_id
-                except bson.errors.InvalidId, ex:
+                except bson.errors.InvalidId as ex:
                     self.log.exception(ex)
                     self.log.error(
                         "Wrong ID '%s' value passed as object ID", doc_id)

--- a/app/handlers/boot_regressions.py
+++ b/app/handlers/boot_regressions.py
@@ -59,7 +59,7 @@ class BootRegressionsHandler(hbase.BaseHandler):
 
         try:
             obj_id = bson.objectid.ObjectId(doc_id)
-        except bson.errors.InvalidId, ex:
+        except bson.errors.InvalidId as ex:
             self.log.exception(ex)
             self.log.error("Provided doc ID '%s' is not valid", doc_id)
             response = hresponse.HandlerResponse()

--- a/app/handlers/build_logs.py
+++ b/app/handlers/build_logs.py
@@ -73,7 +73,7 @@ class BuildLogsHandler(hbase.BaseHandler):
             else:
                 response.status_code = 404
                 response.reason = "Resource '%s' not found" % doc_id
-        except bson.errors.InvalidId, ex:
+        except bson.errors.InvalidId as ex:
             self.log.exception(ex)
             self.log.error("Provided doc ID '%s' is not valid", doc_id)
             response.status_code = 400

--- a/app/handlers/common/query.py
+++ b/app/handlers/common/query.py
@@ -131,7 +131,7 @@ def _parse_and_add_gte_lt_value(
         if val_type and val_type == "int":
             try:
                 value = int(value)
-            except ValueError, ex:
+            except ValueError as ex:
                 utils.LOG.error(
                     "Error converting value to %s: %s",
                     val_type, value)
@@ -141,7 +141,7 @@ def _parse_and_add_gte_lt_value(
         if field is not None and _valid_value(value):
             _add_gte_lt_value(
                 field, value, operator, spec, spec_get_func)
-    except ValueError, ex:
+    except ValueError as ex:
         error_msg = (
             "Wrong value specified for '%s' query argument: %s" %
             (operator, arg)
@@ -256,7 +256,7 @@ def get_query_spec(query_args_func, valid_keys):
                     if val_type and val_type == "int":
                         try:
                             val = int(val[0])
-                        except ValueError, ex:
+                        except ValueError as ex:
                             utils.LOG.error(
                                 "Error converting value to %s: %s",
                                 val_type, val[0])
@@ -269,7 +269,7 @@ def get_query_spec(query_args_func, valid_keys):
                     if val_type and val_type == "int":
                         try:
                             val = {"$in": [int(v) for v in val]}
-                        except ValueError, ex:
+                        except ValueError as ex:
                             utils.LOG.error(
                                 "Error converting list of values to %s: %s",
                                 val_type, val)

--- a/app/handlers/compare.py
+++ b/app/handlers/compare.py
@@ -100,7 +100,7 @@ class CompareHandler(hbase.BaseHandler):
                         response = hresponse.HandlerResponse(400)
                         response.reason = "Provided JSON is not valid"
                         response.errors = errors
-                except ValueError, ex:
+                except ValueError as ex:
                     self.log.exception(ex)
                     error = "No JSON data found in the POST request"
                     self.log.error(error)
@@ -215,7 +215,7 @@ class CompareHandler(hbase.BaseHandler):
             else:
                 response.status_code = 404
                 response.reason = "Resource '%s' not found" % doc_id
-        except bson.errors.InvalidId, ex:
+        except bson.errors.InvalidId as ex:
             self.log.exception(ex)
             self.log.error("Provided doc ID '%s' is not valid", doc_id)
             response.status_code = 400

--- a/app/handlers/job.py
+++ b/app/handlers/job.py
@@ -121,7 +121,7 @@ class JobHandler(hbase.BaseHandler):
             else:
                 response.status_code = 404
                 response.reason = self._get_status_message(404)
-        except bson.errors.InvalidId, ex:
+        except bson.errors.InvalidId as ex:
             self.log.exception(ex)
             self.log.error("Invalid ID specified: %s", job_id)
             response.status_code = 400

--- a/app/handlers/job_logs.py
+++ b/app/handlers/job_logs.py
@@ -73,7 +73,7 @@ class JobLogsHandler(hbase.BaseHandler):
             else:
                 response.status_code = 404
                 response.reason = "Resource '%s' not found" % doc_id
-        except bson.errors.InvalidId, ex:
+        except bson.errors.InvalidId as ex:
             self.log.exception(ex)
             self.log.error("Provided doc ID '%s' is not valid", doc_id)
             response.status_code = 400

--- a/app/handlers/test_base.py
+++ b/app/handlers/test_base.py
@@ -83,7 +83,7 @@ class TestBaseHandler(hbase.BaseHandler):
                                     j_reason)
                             else:
                                 response.reason = "Provided JSON is not valid"
-                    except ValueError, ex:
+                    except ValueError as ex:
                         self.log.exception(ex)
                         error = "No JSON data found in the PUT request"
                         self.log.error(error)
@@ -131,7 +131,7 @@ class TestBaseHandler(hbase.BaseHandler):
                 error = "Test group with ID '%s' not found" % test_group_id
             else:
                 group_name = test_group[models.NAME_KEY]
-        except bson.errors.InvalidId, ex:
+        except bson.errors.InvalidId as ex:
             error = "Test group ID '%s' is not valid" % test_group_id
             self.log.exception(ex)
             self.log.error(error)

--- a/app/handlers/token.py
+++ b/app/handlers/token.py
@@ -143,7 +143,7 @@ class TokenHandler(hbase.BaseHandler):
                         response = hresponse.HandlerResponse(400)
                         response.reason = "Provided JSON is not valid"
                         response.errors = errors
-                except ValueError, ex:
+                except ValueError as ex:
                     self.log.exception(ex)
                     error = "No JSON data found in the PUT request"
                     self.log.error(error)
@@ -190,7 +190,7 @@ class TokenHandler(hbase.BaseHandler):
         except (TypeError, ValueError):
             response.status_code = 400
             response.reason = "Wrong field value or type in the JSON data"
-        except Exception, ex:
+        except Exception as ex:
             response.status_code = 400
             response.reason = str(ex)
 
@@ -224,20 +224,20 @@ class TokenHandler(hbase.BaseHandler):
                     response.result = {models.TOKEN_KEY: token.token}
             else:
                 response.status_code = 404
-        except bson.errors.InvalidId, ex:
+        except bson.errors.InvalidId as ex:
             self.log.exception(ex)
             self.log.error("Wrong ID '%s' value passed for object ID", doc_id)
             response.status_code = 400
             response.reason = "Wrong ID value provided"
-        except KeyError, ex:
+        except KeyError as ex:
             self.log.exception(ex)
             response.status_code = 400
             response.reason = "Mandatory field missing"
-        except (TypeError, ValueError), ex:
+        except (TypeError, ValueError) as ex:
             self.log.exception(ex)
             response.status_code = 400
             response.reason = "Wrong field value or type in the JSON data"
-        except Exception, ex:
+        except Exception as ex:
             self.log.exception(ex)
             response.status_code = 400
             response.reason = str(ex)
@@ -344,7 +344,7 @@ class TokenHandler(hbase.BaseHandler):
             else:
                 response.status_code = 404
                 response.reason = "Resource '%s' not found" % doc_id
-        except bson.errors.InvalidId, ex:
+        except bson.errors.InvalidId as ex:
             error = "Wrong ID value '%s' passed" % doc_id
             self.log.exception(ex)
             self.log.error(error)

--- a/app/handlers/upload.py
+++ b/app/handlers/upload.py
@@ -107,7 +107,7 @@ class UploadHandler(hbase.BaseHandler):
                             job, branch, kernel, arch, defconfig_full)
                         if lab is not None:
                             path = os.path.join(path, lab)
-                    except tornado.web.MissingArgumentError, ex:
+                    except tornado.web.MissingArgumentError as ex:
                         self.log.exception(ex)
                         response = hresponse.HandlerResponse(
                             ex.status_code)

--- a/app/models/token.py
+++ b/app/models/token.py
@@ -434,7 +434,7 @@ def check_expires_date(value):
     try:
         if value:
             value = datetime.datetime.strptime(value, "%Y-%m-%d")
-    except ValueError, ex:
+    except ValueError as ex:
         raise ex
     else:
         return value

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -96,7 +96,7 @@ def update_id_fields(spec):
         for key in common_keys:
             try:
                 spec[key] = bson.objectid.ObjectId(spec[key])
-            except bson.errors.InvalidId, ex:
+            except bson.errors.InvalidId as ex:
                 # We remove the key since it won't serve anything good.
                 utils.LOG.error(
                     "Wrong ID value for key '%s', got '%s': ignoring",

--- a/app/utils/boot/__init__.py
+++ b/app/utils/boot/__init__.py
@@ -165,7 +165,7 @@ def save_to_disk(boot_doc, json_obj, base_path, errors):
         if not os.path.isdir(dir_path):
             try:
                 os.makedirs(dir_path)
-            except OSError, ex:
+            except OSError as ex:
                 if ex.errno != errno.EEXIST:
                     raise ex
 
@@ -177,7 +177,7 @@ def save_to_disk(boot_doc, json_obj, base_path, errors):
                     encoding="utf-8"
                 )
             )
-    except (OSError, IOError), ex:
+    except (OSError, IOError) as ex:
         err_msg = "Error saving boot report to '{}'".format(file_path)
         utils.LOG.exception(ex)
         utils.LOG.error(err_msg)
@@ -414,7 +414,7 @@ def _parse_boot_from_json(boot_json, database, errors):
 
     try:
         _check_for_null(boot_json)
-    except BootValidationError, ex:
+    except BootValidationError as ex:
         utils.LOG.exception(ex)
         ERR_ADD(errors, 400, str(ex))
         return None
@@ -427,7 +427,7 @@ def _parse_boot_from_json(boot_json, database, errors):
         lab_name = boot_json[models.LAB_NAME_KEY]
         git_branch = boot_json[models.GIT_BRANCH_KEY]
         build_environment = boot_json[models.BUILD_ENVIRONMENT_KEY]
-    except KeyError, ex:
+    except KeyError as ex:
         err_msg = "Missing mandatory key in boot data"
         utils.LOG.exception(ex)
         utils.LOG.error(err_msg)
@@ -474,7 +474,7 @@ def import_and_save_boot(json_obj, db_options, base_path=utils.BASE_PATH):
             save_to_disk(doc, json_obj, base_path, errors)
         else:
             utils.LOG.warn("No boot report imported nor saved")
-    except pymongo.errors.ConnectionFailure, ex:
+    except pymongo.errors.ConnectionFailure as ex:
         utils.LOG.exception(ex)
         utils.LOG.error("Error getting database connection")
         ERR_ADD(errors, 500, "Error connecting to the database")

--- a/app/utils/build/__init__.py
+++ b/app/utils/build/__init__.py
@@ -296,7 +296,7 @@ def parse_build_data(build_data, job, kernel, build_dir):
             models.MODULES_SIZE_KEY: build_doc.modules,
             models.SYSTEM_MAP_SIZE_KEY: build_doc.system_map,
         }
-    except KeyError, ex:
+    except KeyError as ex:
         msg = "Missing mandatory key '%s' in build data (job: %s, kernel: %s)"
         raise BuildError(500, msg % (ex.args[0], job, kernel), from_exc=ex)
 
@@ -330,17 +330,17 @@ def _traverse_build_dir(build_dir, job_doc, errors, database):
                 utils.LOG.error(err_msg)
                 ERR_ADD(errors, 500, err_msg)
                 return
-        except OSError, ex:
+        except OSError as ex:
             err_msg = "Error retrieving build data file size"
             utils.LOG.error(err_msg)
             utils.LOG.exception(ex)
             ERR_ADD(errors, 500, err_msg)
-        except IOError, ex:
+        except IOError as ex:
             err_msg = "Error reading json data file from {}".format(build_dir)
             utils.LOG.exception(ex)
             utils.LOG.error(err_msg)
             ERR_ADD(errors, 500, err_msg)
-        except json.JSONDecodeError, ex:
+        except json.JSONDecodeError as ex:
             err_msg = "Error loading json data from {}".format(build_dir)
             utils.LOG.exception(ex)
             utils.LOG.error(err_msg)
@@ -565,7 +565,7 @@ def import_single_build(json_obj, db_options, base_path=utils.BASE_PATH):
                         ret_val, err_msg % (
                             job, git_branch, kernel, arch, defconfig,
                             build_environment))
-            except pymongo.errors.ConnectionFailure, ex:
+            except pymongo.errors.ConnectionFailure as ex:
                 utils.LOG.exception(ex)
                 utils.LOG.error("Error getting database connection")
                 utils.LOG.warn(

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -282,7 +282,7 @@ def save(database, document):
                 result = collection.insert_one(doc_data)
                 doc_id = result.inserted_id
             ret_value = 201
-        except pymongo.errors.OperationFailure, ex:
+        except pymongo.errors.OperationFailure as ex:
             utils.LOG.error("Error saving document into {}".format(collection))
             utils.LOG.exception(ex)
     else:
@@ -416,7 +416,7 @@ def update(collection, spec, document, operation="$set"):
 
     try:
         collection.find_one_and_update(spec, {operation: document})
-    except pymongo.errors.OperationFailure, ex:
+    except pymongo.errors.OperationFailure as ex:
         utils.LOG.exception(str(ex))
         ret_val = 500
 
@@ -439,7 +439,7 @@ def update2(connection, collection, search, document):
     ret_val = 200
     try:
         connection[collection].find_one_and_replace(search, document)
-    except pymongo.errors.OperationFailure, ex:
+    except pymongo.errors.OperationFailure as ex:
         utils.LOG.exception(str(ex))
         ret_val = 500
 
@@ -464,7 +464,7 @@ def update3(collection, search, document, db_options=None):
     db = get_db_connection2(db_options)
     try:
         db[collection].find_one_and_replace(search, document)
-    except pymongo.errors.OperationFailure, ex:
+    except pymongo.errors.OperationFailure as ex:
         utils.LOG.exception(str(ex))
         ret_val = 500
 
@@ -494,7 +494,7 @@ def find_and_update(collection, query, document, operation="$set"):
         if not result:
             utils.LOG.error("Document with query '%s' not found", query)
             ret_val = 404
-    except pymongo.errors.OperationFailure, ex:
+    except pymongo.errors.OperationFailure as ex:
         ret_val = 500
         utils.LOG.error(
             "Error searching and updating the document with query: %s", query)
@@ -517,7 +517,7 @@ def delete(collection, spec_or_id):
 
     try:
         collection.remove(spec_or_id)
-    except pymongo.errors.OperationFailure, ex:
+    except pymongo.errors.OperationFailure as ex:
         utils.LOG.error(
             "Error removing the following document: %s", str(spec_or_id))
         utils.LOG.exception(str(ex))

--- a/app/utils/emails.py
+++ b/app/utils/emails.py
@@ -229,20 +229,22 @@ def send_email(subject, txt_body, html_body, email_opts, config, headers=None):
 
             server.sendmail(from_addr, send_to, email_msg)
             status = models.SENT_STATUS
-        except (smtplib.SMTPAuthenticationError, smtplib.SMTPConnectError), ex:
+        except (smtplib.SMTPAuthenticationError,
+                smtplib.SMTPConnectError) as ex:
             utils.LOG.error("SMTP conn/auth error")
             errors.append((ex.smtp_code, ex.smtp_error))
-        except (smtplib.SMTPRecipientsRefused, smtplib.SMTPSenderRefused), ex:
+        except (smtplib.SMTPRecipientsRefused,
+                smtplib.SMTPSenderRefused) as ex:
             utils.LOG.error(
                 "Error sending email: recipients or sender refused")
             errors.append((ex.smtp_code, ex.smtp_error))
-        except (smtplib.SMTPHeloError, smtplib.SMTPDataError), ex:
+        except (smtplib.SMTPHeloError, smtplib.SMTPDataError) as ex:
             utils.LOG.error("SMTP server error")
             errors.append((ex.smtp_code, ex.smtp_error))
-        except smtplib.SMTPException, ex:
+        except smtplib.SMTPException as ex:
             utils.LOG.error("Generic SMTP error: no auth method, ...")
             errors.append((ex.smtp_code, ex.smtp_error))
-        except Exception, ex:
+        except Exception as ex:
             utils.LOG.exception(ex)
             utils.LOG.error(
                 "Unexpected SMTP error: %s", str(ex))

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -302,7 +302,7 @@ def _parse_test_case_from_json(group_name, group_doc_id, test_case,
     """
     try:
         _check_for_null(test_case, NON_NULL_KEYS_CASE)
-    except TestValidationError, ex:
+    except TestValidationError as ex:
         utils.LOG.exception(ex)
         ERR_ADD(errors, 400, str(ex))
         return None
@@ -310,7 +310,7 @@ def _parse_test_case_from_json(group_name, group_doc_id, test_case,
     try:
         name = test_case[models.NAME_KEY]
         status = test_case[models.STATUS_KEY].upper()
-    except KeyError, ex:
+    except KeyError as ex:
         err_msg = "Missing mandatory key in test case data"
         utils.LOG.exception(ex)
         utils.LOG.error(err_msg)
@@ -502,7 +502,7 @@ def _parse_test_group_from_json(test_json, database, errors):
 
     try:
         _check_for_null(test_json, NON_NULL_KEYS_GROUP)
-    except TestValidationError, ex:
+    except TestValidationError as ex:
         utils.LOG.exception(ex)
         ERR_ADD(errors, 400, str(ex))
         return None
@@ -510,7 +510,7 @@ def _parse_test_group_from_json(test_json, database, errors):
     try:
         name = test_json[models.NAME_KEY]
         lab_name = test_json[models.LAB_NAME_KEY]
-    except KeyError, ex:
+    except KeyError as ex:
         err_msg = "Missing mandatory key in test group data"
         utils.LOG.exception(ex)
         utils.LOG.error(err_msg)
@@ -669,7 +669,7 @@ def import_and_save_kci_tests(group, db_options, base_path=utils.BASE_PATH):
             ret_code = 201
             # TODO fix this: need to define a save_to_disk method
             # save_to_disk(ts_doc, test_group_obj, base_path, errors)
-    except pymongo.errors.ConnectionFailure, ex:
+    except pymongo.errors.ConnectionFailure as ex:
         utils.LOG.exception(ex)
         utils.LOG.error("Error getting database connection")
         ERR_ADD(errors, 500, "Error connecting to the database")

--- a/app/utils/log_parser.py
+++ b/app/utils/log_parser.py
@@ -543,7 +543,7 @@ def _parse_log(build_doc, log_file, build_dir, errors):
                 if re.search(MISMATCH_PATTERN, line):
                     line = line.strip()
                     mismatch_append(_clean_path(line))
-    except IOError, ex:
+    except IOError as ex:
         err_msg = "Cannot read build log file {}".format(log_file)
         utils.LOG.exception(ex)
         utils.LOG.error(err_msg)
@@ -555,7 +555,7 @@ def _parse_log(build_doc, log_file, build_dir, errors):
         _save_lines(error_lines, errors_file)
         _save_lines(warning_lines, warnings_file)
         _save_lines(mismatch_lines, mismatches_file)
-    except IOError, ex:
+    except IOError as ex:
         err_msg = "Error writing errors/warnings file for {}-{}-{}-{}".format(
             build_doc.job,
             build_doc.git_branch, build_doc.kernel, build_doc.defconfig_full

--- a/app/utils/logs/build.py
+++ b/app/utils/logs/build.py
@@ -64,7 +64,7 @@ def create_build_logs_summary(job, kernel, git_branch, db_options):
                     for line in itertools.chain(errors, warnings, mismatches):
                         to_write.write(
                             u"{:>4d} {:s}\n".format(line[0], line[1]))
-            except IOError, ex:
+            except IOError as ex:
                 ret_val = 500
                 error = (
                     "Error writing logs summary for {}-{}-{}: {}".format(

--- a/app/utils/tests_import.py
+++ b/app/utils/tests_import.py
@@ -371,7 +371,7 @@ def import_test_case(
                         doc_id, group_oid, group_name, database)
             else:
                 ADD_ERR(errors, 400, "Missing mandatory key in JSON data")
-        except ValueError, ex:
+        except ValueError as ex:
             ADD_ERR(errors, 400, "Error parsing test case '%s'" % test_name)
             error = (
                 "Error parsing test case '{}': {}".format(test_name, ex))

--- a/app/utils/upload.py
+++ b/app/utils/upload.py
@@ -74,7 +74,7 @@ def check_or_create_upload_dir(path, base_path=utils.BASE_PATH):
     else:
         try:
             os.makedirs(real_path, mode=0775)
-        except OSError, ex:
+        except OSError as ex:
             # errno.EEXIST (17) means the directory already exists, so do not
             # treat it as an error.
             if ex.errno != errno.EEXIST:
@@ -145,7 +145,7 @@ def create_or_update_file(path,
             w_stream = io.open(real_path, mode="bw")
             ret_dict["bytes"] = w_stream.write(content)
             w_stream.flush()
-        except IOError, ex:
+        except IOError as ex:
             utils.LOG.exception(ex)
             utils.LOG.error("Unable to open file '%s'", file_path)
             ret_dict["status"] = 500


### PR DESCRIPTION
"except Foo, ex" is a syntax error in python3.
Convert all occurances to "except Foo as ex"

Signed-off-by: Kevin Hilman <khilman@baylibre.com>