### PR TITLE
Push test results from LAVA callbacks to BigQuery using kcidb

### DIFF
--- a/app/taskqueue/tasks/kcidb.py
+++ b/app/taskqueue/tasks/kcidb.py
@@ -30,3 +30,11 @@ def push_build(args):
         utils.kcidb.push_build(build_id, first, bq_options,
                                taskc.app.conf.db_options)
     return build_id, job_id
+
+
+@taskc.app.task(name="kcidb-tests")
+def push_tests(group_id):
+    bq_options = taskc.app.conf.get("BigQuery_options")
+    if bq_options:
+        utils.kcidb.push_tests(group_id, bq_options, taskc.app.conf.db_options)
+    return group_id

--- a/app/utils/kcidb.py
+++ b/app/utils/kcidb.py
@@ -190,6 +190,7 @@ def push_tests(group_id, bq_options, db_options={}, db=None):
         url = "/".join([
             STORAGE_URL,
             build[models.FILE_SERVER_RESOURCE_KEY],
+            group[models.LAB_NAME_KEY],
             file])
         output_files.append({"name": name, "url": url})
 

--- a/app/utils/kcidb.py
+++ b/app/utils/kcidb.py
@@ -179,6 +179,20 @@ def push_tests(group_id, bq_options, db_options={}, db=None):
         'instance': group[models.BOARD_INSTANCE_KEY],
     }
 
+    files = {
+        'txt': group[models.BOOT_LOG_KEY],
+        'html': group[models.BOOT_LOG_HTML_KEY],
+        'lava_json': 'lava-{}.json'.format(group[models.DEVICE_TYPE_KEY]),
+    }
+
+    output_files = []
+    for name, file in files.iteritems():
+        url = "/".join([
+            STORAGE_URL,
+            build[models.FILE_SERVER_RESOURCE_KEY],
+            file])
+        output_files.append({"name": name, "url": url})
+
     bq_data = {
         'version': '1',
         "tests": [
@@ -195,6 +209,7 @@ def push_tests(group_id, bq_options, db_options={}, db=None):
                 'description': test_description,
                 'status': test['status'],
                 'start_time': test['start_time'],
+                'output_files': output_files,
                 'misc': misc,
             }
             for test in test_cases

--- a/app/utils/kcidb.py
+++ b/app/utils/kcidb.py
@@ -154,6 +154,9 @@ def push_tests(group_id, bq_options, db_options={}, db=None):
     ns = bq_options.get("namespace", "kernelci.org")
     test_cases = _get_test_cases(group, db, [], ns)
     build = _get_build_doc(group, db)
+    if not build:
+        utils.LOG.warn("kcidb: Missing build, unable to push tests.")
+        return
     build_id = _make_id(build[models.ID_KEY], ns)
     env_description = "{} in {}".format(
         group[models.DEVICE_TYPE_KEY],


### PR DESCRIPTION
Push test results in real time from LAVA callbacks to BigQuery using kcidb.

The start time is not the actual time when the test started but rather when it was saved in the Mongo DB.  This can be improved by using timestamps from the LAVA log.

Non-LAVA labs aren't covered by this PR, this should be done as a follow-up PR.