### PR TITLE
callback/lava: use board-instance for log files

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -292,7 +292,7 @@ def _add_test_log(meta, job_log, suite):
     dir_path = meta[models.DIRECTORY_PATH]
 
     utils.LOG.info("Generating {} log files in {}".format(suite, dir_path))
-    file_name = "-".join([suite, meta[models.BOARD_KEY]])
+    file_name = "-".join([suite, meta[models.BOARD_INSTANCE_KEY]])
     files = tuple(".".join([file_name, ext]) for ext in ["txt", "html"])
     meta[models.BOOT_LOG_KEY], meta[models.BOOT_LOG_HTML_KEY] = files
     txt_path, html_path = (os.path.join(dir_path, f) for f in files)
@@ -322,7 +322,7 @@ def _store_lava_json(job_data, meta, base_path=utils.BASE_PATH):
     :type base_path: string
     """
 
-    file_name = "-".join(["lava-json", meta[models.BOARD_KEY]])
+    file_name = "-".join(["lava-json", meta[models.BOARD_INSTANCE_KEY]])
     file_name = ".".join([file_name, "json"])
 
     dir_path = meta[models.DIRECTORY_PATH]
@@ -509,6 +509,7 @@ def _add_test_results(group, suite_results, suite_name):
             k: group[k] for k in [
                 models.ARCHITECTURE_KEY,
                 models.BOARD_KEY,
+                models.BOARD_INSTANCE_KEY,
                 models.BUILD_ENVIRONMENT_KEY,
                 models.DEFCONFIG_FULL_KEY,
                 models.DEFCONFIG_KEY,


### PR DESCRIPTION
Currently the log files are generated based on the LAVA device-type
(models.BOARD_KEY, which comes from the platform.name metadata.)

If there are multiple instances of a given device-type in a lab, the
log files will be identical, so will clash and the most recently
arrived job will overwrite any logs from previous jobs.

To avoid this, use BOARD_INSTANCE_KEY instead of BOARD_KEY when
generating the log file names.

While here, ensure that the BOARD_INSTANCE_KEY is among the sub_group
keys updated when new test reports arrive.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>