### PR TITLE
Modify tests to use new mongomock API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ script:
   - >
     for dir in
     models/tests
+    utils/tests
+    utils/build/tests
     utils/bisect/tests
+    handlers/common/tests
     utils/report/tests;
     do
       echo Running tests in $dir

--- a/app/handlers/common/tests/test_lab.py
+++ b/app/handlers/common/tests/test_lab.py
@@ -33,7 +33,7 @@ class TestLabCommon(unittest.TestCase):
     def setUp(self):
         super(TestLabCommon, self).setUp()
         logging.disable(logging.CRITICAL)
-        self.database = mongomock.Connection()["kernel-ci"]
+        self.database = mongomock.MongoClient()["kernel-ci"]
         self.doc_id = "".join(
             [random.choice(string.digits) for x in xrange(24)])
         self.valid_keys = [

--- a/app/handlers/tests/test_handler_base.py
+++ b/app/handlers/tests/test_handler_base.py
@@ -40,7 +40,7 @@ class TestHandlerBase(AsyncHTTPTestCase, LogTrapTestCase):
         # Default Content-Type header returned by Tornado.
         self.content_type = "application/json; charset=UTF-8"
         self.req_token = mtoken.Token()
-        self.database = mongomock.Connection()["kernel-ci"]
+        self.database = mongomock.MongoClient()["kernel-ci"]
         self.redisdb = fakeredis.FakeStrictRedis()
         self.dboptions = {
             "mongodb_password": "",

--- a/app/utils/boot/tests/test_boot_import.py
+++ b/app/utils/boot/tests/test_boot_import.py
@@ -43,7 +43,8 @@ class TestParseBoot(unittest.TestCase):
 
     def setUp(self):
         logging.disable(logging.CRITICAL)
-        self.db = mongomock.Database(mongomock.Connection(), "kernel-ci")
+        self.db = mongomock.Database(mongomock.MongoClient(),
+                                     "kernel-ci", None)
         self.base_path = tempfile.gettempdir()
 
         self.boot_report = dict(

--- a/app/utils/boot/tests/test_boot_regressions.py
+++ b/app/utils/boot/tests/test_boot_regressions.py
@@ -32,7 +32,8 @@ class TestBootRegressions(unittest.TestCase):
 
     def setUp(self):
         logging.disable(logging.CRITICAL)
-        self.db = mongomock.Database(mongomock.Connection(), "kernel-ci")
+        self.db = mongomock.Database(mongomock.MongoClient(),
+                                     "kernel-ci", None)
 
         self.boot_id = "".join(
             [random.choice(string.digits) for x in xrange(24)])

--- a/app/utils/build/tests/test_build_import.py
+++ b/app/utils/build/tests/test_build_import.py
@@ -44,7 +44,8 @@ class TestBuildUtils(unittest.TestCase):
 
     def setUp(self):
         logging.disable(logging.CRITICAL)
-        self.db = mongomock.Database(mongomock.Connection(), "kernel-ci")
+        self.db = mongomock.Database(mongomock.MongoClient(),
+                                     "kernel-ci", None)
 
         patcher = mock.patch("utils.database.redisdb.get_db_connection")
         mock_open = patcher.start()

--- a/app/utils/compare/tests/test_boot_compare.py
+++ b/app/utils/compare/tests/test_boot_compare.py
@@ -28,7 +28,8 @@ class TestBootCompare(unittest.TestCase):
 
     def setUp(self):
         logging.disable(logging.CRITICAL)
-        self.db = mongomock.Database(mongomock.Connection(), "kernel-ci")
+        self.db = mongomock.Database(mongomock.MongoClient(),
+                                     "kernel-ci", None)
 
         patcher = mock.patch("utils.db.get_db_connection")
         mock_db = patcher.start()

--- a/app/utils/compare/tests/test_build_compare.py
+++ b/app/utils/compare/tests/test_build_compare.py
@@ -28,7 +28,8 @@ class TestBuildCompare(unittest.TestCase):
 
     def setUp(self):
         logging.disable(logging.CRITICAL)
-        self.db = mongomock.Database(mongomock.Connection(), "kernel-ci")
+        self.db = mongomock.Database(mongomock.MongoClient(),
+                                     "kernel-ci", None)
 
         patcher = mock.patch("utils.db.get_db_connection")
         mock_db = patcher.start()

--- a/app/utils/compare/tests/test_job_compare.py
+++ b/app/utils/compare/tests/test_job_compare.py
@@ -28,7 +28,8 @@ class TestJobCompare(unittest.TestCase):
 
     def setUp(self):
         logging.disable(logging.CRITICAL)
-        self.db = mongomock.Database(mongomock.Connection(), "kernel-ci")
+        self.db = mongomock.Database(mongomock.MongoClient(),
+                                     "kernel-ci", None)
 
         patcher = mock.patch("utils.db.get_db_connection")
         mock_db = patcher.start()

--- a/app/utils/kci_test/tests/test_tests.py
+++ b/app/utils/kci_test/tests/test_tests.py
@@ -29,7 +29,8 @@ class TestTests(unittest.TestCase):
 
     def setUp(self):
         logging.disable(logging.CRITICAL)
-        self._db = mongomock.Database(mongomock.Connection(), "kernel-ci")
+        self._db = mongomock.Database(mongomock.MongoClient(),
+                                      "kernel-ci", None)
 
     def tearDown(self):
         logging.disable(logging.NOTSET)

--- a/app/utils/stats/tests/test_daily_stats.py
+++ b/app/utils/stats/tests/test_daily_stats.py
@@ -28,7 +28,8 @@ class TestDailyStats(unittest.TestCase):
 
     def setUp(self):
         logging.disable(logging.CRITICAL)
-        self.db = mongomock.Database(mongomock.Connection(), "kernel-ci")
+        self.db = mongomock.Database(mongomock.MongoClient(),
+                                     "kernel-ci", None)
         self.today = datetime.datetime(
             2015, 8, 10, hour=0, minute=1, second=0, microsecond=0)
 

--- a/app/utils/tests/test_log_parser.py
+++ b/app/utils/tests/test_log_parser.py
@@ -33,7 +33,8 @@ import utils.log_parser as lparser
 class TestBuildLogParser(unittest.TestCase):
 
     def setUp(self):
-        self.db = mongomock.Database(mongomock.Connection(), "kernel-ci")
+        self.db = mongomock.Database(mongomock.MongoClient(),
+                                     "kernel-ci", None)
         logging.disable(logging.CRITICAL)
 
     def tearDown(self):

--- a/app/utils/tests/test_tests_import.py
+++ b/app/utils/tests/test_tests_import.py
@@ -31,7 +31,8 @@ class TestTestsImport(unittest.TestCase):
 
     def setUp(self):
         logging.disable(logging.CRITICAL)
-        self.db = mongomock.Database(mongomock.Connection(), 'kernel-ci')
+        self.db = mongomock.Database(mongomock.MongoClient(),
+                                     "kernel-ci", None)
 
     def tearDown(self):
         logging.disable(logging.NOTSET)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 lupa
 mock>0.7.2
-mongomock==2.0.0
+mongomock==3.18.0
 fakeredis


### PR DESCRIPTION
KernelCI Backend MongoDB has been update, hence PyMongo has been
upgraded to version 3.9. This commit upgrades mongomock to version 3.18
to support PyMongo API changes.

Signed-off-by: Michal Galka <michal.galka@collabora.com>