### PR TITLE
Fix unittests

### DIFF
--- a/app/handlers/tests/test_build_handler.py
+++ b/app/handlers/tests/test_build_handler.py
@@ -152,7 +152,7 @@ class TestBuildHandler(TestHandlerBase):
             response.headers["Content-Type"], self.content_type)
 
     def test_delete(self):
-        self.database["build"].insert(dict(_id=self.doc_id, job_id="job"))
+        self.database["build"].insert_one(dict(_id=self.doc_id, job_id="job"))
 
         headers = {"Authorization": "foo"}
 

--- a/app/handlers/tests/test_compare_handler.py
+++ b/app/handlers/tests/test_compare_handler.py
@@ -232,7 +232,7 @@ class TestCompareHandler(TestHandlerBase):
     @mock.patch("bson.objectid.ObjectId")
     def test_delete_with_token_with_job(self, mock_id):
         mock_id.return_value = "job"
-        self.database["job"].insert(
+        self.database["job"].insert_one(
             dict(_id="job", job="job", kernel="kernel"))
         headers = {"Authorization": "foo"}
 

--- a/app/handlers/tests/test_job_handler.py
+++ b/app/handlers/tests/test_job_handler.py
@@ -24,6 +24,7 @@ except ImportError:
 
 import mock
 import tornado
+import unittest
 
 import urls
 
@@ -80,6 +81,7 @@ class TestJobHandler(TestHandlerBase):
             response.headers["Content-Type"], self.content_type)
         self.assertDictEqual(json.loads(response.body), expected_body)
 
+    @unittest.skip("Mongomock bug in count handling for skip > count")
     @mock.patch("utils.db.find")
     @mock.patch("utils.db.count")
     def test_get_with_limit_and_skip(self, mock_count, mock_find):

--- a/app/handlers/tests/test_job_handler.py
+++ b/app/handlers/tests/test_job_handler.py
@@ -276,7 +276,7 @@ class TestJobHandler(TestHandlerBase):
     @mock.patch("bson.objectid.ObjectId")
     def test_delete_with_token_with_job(self, mock_id):
         mock_id.return_value = "job"
-        self.database["job"].insert(
+        self.database["job"].insert_one(
             dict(_id="job", job="job", kernel="kernel"))
         headers = {"Authorization": "foo"}
 

--- a/app/handlers/tests/test_token_handler.py
+++ b/app/handlers/tests/test_token_handler.py
@@ -418,7 +418,7 @@ class TestTokenHandler(TestHandlerBase):
     def test_delete_with_token_with_document(self, mock_id):
         mock_id.return_value = "token"
 
-        self.database["api-token"].insert(
+        self.database["api-token"].insert_one(
             dict(_id="token", token="token", email="email"))
 
         headers = {"Authorization": "foo"}
@@ -435,7 +435,7 @@ class TestTokenHandler(TestHandlerBase):
         self.assertEqual(response.code, 404)
 
     def test_delete_wrong_id_value(self):
-        self.database["api-token"].insert(
+        self.database["api-token"].insert_one(
             dict(_id="token", token="token", email="email"))
 
         headers = {"Authorization": "foo"}

--- a/app/utils/boot/tests/test_boot_regressions.py
+++ b/app/utils/boot/tests/test_boot_regressions.py
@@ -173,7 +173,7 @@ class TestBootRegressions(unittest.TestCase):
         self.assertTupleEqual((None, None), results)
 
     @mock.patch("utils.db.find_one3")
-    @mock.patch("utils.db.get_db_connection")
+    @mock.patch("utils.db.get_db_connection2")
     def test_find_not_fail(self, mock_db, mock_find):
         mock_find.return_value = {"status": "PASS"}
 
@@ -181,7 +181,7 @@ class TestBootRegressions(unittest.TestCase):
         self.assertTupleEqual((None, None), results)
 
     @mock.patch("utils.db.find_one3")
-    @mock.patch("utils.db.get_db_connection")
+    @mock.patch("utils.db.get_db_connection2")
     def test_find_no_old_doc(self, mock_db, mock_find):
         mock_find.side_effects = [self.fail_boot, None]
 

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -253,7 +253,7 @@ def count(collection):
     :param collection: The collection whose documents should be counted.
     :return The number of documents in the collection.
     """
-    return collection.count_documents()
+    return collection.count_documents({})
 
 
 def save(database, document):


### PR DESCRIPTION
This PR adds more unittest fixes for kernelci-backend

Fix mock to patch correct DB connecting function. 

New PyMongo API requires filter parameter when counting
documents. Added empty dictionary to satisfy this requirement.

There is a bug in mongomock implemenation that returns negative value
when number of skipped documents is bigger that the number of documents
found. Skipping the test that uses it till it's fixed in Mongomock.

**mongomock bugged code excerpt**

```python
count = len(list(self._iter_documents(filter)))
        if limit is None:
            return count - skip
        return min(count - skip, limit)
```