### PR TITLE
Enable Travis CI in handlers/tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
     utils/build/tests
     utils/bisect/tests
     handlers/common/tests
+    handlers/tests
     utils/report/tests;
     do
       echo Running tests in $dir


### PR DESCRIPTION
Now that these unit tests are fixed, enable them again in Travis CI.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>