### PR TITLE
Enable handler/tests in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
     utils/build/tests
     utils/bisect/tests
     handlers/common/tests
+    handlers/tests
     utils/report/tests;
     do
       echo Running tests in $dir

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ simplejson
 sphinx-bootstrap-theme
 sphinxcontrib-httpdomain==1.3.0
 tornado==3.2.2
+six==1.13.0


### PR DESCRIPTION
Re-enables handler/tests in TravisCI and sets six package version
to 1.13.0. Versiion 1.11.0 of the six package was implicitly causing  installed
it's now set explicitly to 1.13.0 in requirements.txt.

Signed-off-by: Michal Galka <michal.galka@collabora.com>