### PR TITLE
Do not include recipients in bisection report hash

### DIFF
--- a/app/utils/report/bisect.py
+++ b/app/utils/report/bisect.py
@@ -80,8 +80,6 @@ def create_bisect_report(data, email_options, db_options,
     report_hashable_str = "-".join(str(x) for x in [
         doc[models.BISECT_FOUND_SUMMARY_KEY],
         doc[models.KERNEL_KEY],
-        email_options["to"],
-        email_options["cc"],
     ])
     report_hash = hashlib.sha1(report_hashable_str).hexdigest()
     redisdb_conn = redisdb.get_db_connection(db_options)


### PR DESCRIPTION
To avoid duplicates when the recipients are slightly different or not
in the same order, only include the kernel revision and the found git
commit summary in the bisection report hash.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>
Fixes: f1e859a45362 ("Do not send the same boot bisection report more than once")