### PR TITLE
Fix collection name in index creation handler

### DIFF
--- a/app/handlers/dbindexes.py
+++ b/app/handlers/dbindexes.py
@@ -226,7 +226,7 @@ def ensure_indexes(database):
     :param database: The database connection.
     """
     for collection, index_specs in INDEX_SPECS.iteritems():
-        db_collection = database[models.BUILD_COLLECTION]
+        db_collection = database[collection]
         db_indexes = db_collection.index_information()
 
         for index in index_specs:


### PR DESCRIPTION
The collection name was hard-coded to "builds" due to a mistake in a
previous commit.  Fix the collection name used when creating indexes
to create all the required indexes as intended.

Fixes: 6fd607fdbee3 ("Use Collection.create_index() rather than .ensure_index()")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>