### PR TITLE
T18074 test plan indexes

### DIFF
--- a/app/handlers/dbindexes.py
+++ b/app/handlers/dbindexes.py
@@ -187,6 +187,19 @@ INDEX_SPECS = {
             (models.JOB_KEY, pymongo.ASCENDING),
             (models.KERNEL_KEY, pymongo.ASCENDING),
             (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
+            (models.PLAN_KEY, pymongo.ASCENDING),
+        ],
+        [
+            (models.JOB_KEY, pymongo.ASCENDING),
+            (models.KERNEL_KEY, pymongo.ASCENDING),
+            (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
+            (models.STATUS_KEY, pymongo.ASCENDING),
+            (models.PLAN_KEY, pymongo.ASCENDING),
+        ],
+        [
+            (models.JOB_KEY, pymongo.ASCENDING),
+            (models.KERNEL_KEY, pymongo.ASCENDING),
+            (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
             (models.STATUS_KEY, pymongo.ASCENDING),
             (models.REGRESSION_ID_KEY, pymongo.ASCENDING),
         ],
@@ -210,6 +223,12 @@ INDEX_SPECS = {
             (models.JOB_KEY, pymongo.ASCENDING),
             (models.KERNEL_KEY, pymongo.ASCENDING),
             (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
+        ],
+        [
+            (models.JOB_KEY, pymongo.ASCENDING),
+            (models.KERNEL_KEY, pymongo.ASCENDING),
+            (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
+            (models.PLAN_KEY, pymongo.ASCENDING),
         ],
     ],
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -896,6 +896,8 @@ TEST_GROUP_VALID_KEYS = {
         DEFCONFIG_FULL_KEY,
         DEFCONFIG_KEY,
         GIT_BRANCH_KEY,
+        GIT_COMMIT_KEY,
+        GIT_URL_KEY,
         INDEX_KEY,
         JOB_ID_KEY,
         JOB_KEY,


### PR DESCRIPTION
Add Mongo DB indexes and enable test group fields to be able to create views based on test plans.