### PR TITLE
T18935 Add test/regression API entry point

### DIFF
--- a/app/handlers/dbindexes.py
+++ b/app/handlers/dbindexes.py
@@ -230,6 +230,15 @@ INDEX_SPECS = {
             (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
             (models.PLAN_KEY, pymongo.ASCENDING),
         ],
+        [
+            (models.JOB_KEY, pymongo.ASCENDING),
+            (models.KERNEL_KEY, pymongo.ASCENDING),
+            (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
+            (models.PLAN_KEY, pymongo.ASCENDING),
+            (models.DEVICE_TYPE_KEY, pymongo.ASCENDING),
+            (models.BUILD_ENVIRONMENT_KEY, pymongo.ASCENDING),
+            (models.DEFCONFIG_FULL_KEY, pymongo.ASCENDING),
+        ],
     ],
 
     models.TOKEN_COLLECTION: [

--- a/app/handlers/test_regression.py
+++ b/app/handlers/test_regression.py
@@ -1,0 +1,38 @@
+# Copyright (C) Collabora Limited 2020
+# Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation; either version 2.1 of the License, or (at your option)
+# any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+"""The RequestHandler for /test/regression URLs."""
+
+import handlers.test_base
+import models
+
+
+# pylint: disable=too-many-public-methods
+class TestRegressionHandler(handlers.test_base.TestBaseHandler):
+    """The test regression request handler."""
+
+    def __init__(self, application, request, **kwargs):
+        super(TestRegressionHandler, self).__init__(
+            application, request, **kwargs)
+
+    @property
+    def collection(self):
+        return self.db[models.TEST_REGRESSION_COLLECTION]
+
+    @staticmethod
+    def _valid_keys(method):
+        return models.TEST_REGRESSION_VALID_KEYS.get(method)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -373,7 +373,8 @@ COLLECTIONS = [
     DAILY_STATS_COLLECTION,
     JOB_COLLECTION,
     TEST_CASE_COLLECTION,
-    TEST_GROUP_COLLECTION
+    TEST_GROUP_COLLECTION,
+    TEST_REGRESSION_COLLECTION,
 ]
 
 # Slightly different then above: this is used only for the /count API.
@@ -955,6 +956,18 @@ TEST_CASE_VALID_KEYS = {
         TIME_KEY,
         VERSION_KEY,
     ]
+}
+
+TEST_REGRESSION_VALID_KEYS = {
+    "GET": [
+        JOB_KEY,
+        GIT_BRANCH_KEY,
+        KERNEL_KEY,
+        PLAN_KEY,
+        DEVICE_TYPE_KEY,
+        BUILD_ENVIRONMENT_KEY,
+        DEFCONFIG_FULL_KEY,
+    ],
 }
 
 STATISTICS_VALID_KEYS = {

--- a/app/urls.py
+++ b/app/urls.py
@@ -42,6 +42,7 @@ import handlers.send
 import handlers.stats
 import handlers.test_case
 import handlers.test_group
+import handlers.test_regression
 import handlers.token
 import handlers.upload
 import handlers.version
@@ -177,6 +178,10 @@ _TEST_CASE_COUNT_DISTINCT_URL = tornado.web.url(
     kwargs={"resource": "test_case"}, name="test-case-count-distinct"
 )
 
+_TEST_REGRESSION_URL = tornado.web.url(
+    r"/test[s]?/regression[s]?/?(?P<id>.*)",
+    handlers.test_regression.TestRegressionHandler, name="test-regression")
+
 _BOOT_TRIGGER_URL = tornado.web.url(
     r"/trigger/boot[s]?/?",
     handlers.boot_trigger.BootTriggerHandler, name="boot-trigger")
@@ -220,6 +225,7 @@ APP_URLS = [
     _TEST_GROUP_COUNT_DISTINCT_URL,
     _TEST_GROUP_DISTINCT_URL,
     _TEST_GROUP_URL,
+    _TEST_REGRESSION_URL,
     _TEST_RESULT_URL,
     _TOKEN_URL,
     _UPLOAD_URL,

--- a/app/utils/batch/batch_op.py
+++ b/app/utils/batch/batch_op.py
@@ -277,6 +277,14 @@ class BatchTestGroupOperation(BatchOperation):
         self.valid_keys = models.TEST_GROUP_VALID_KEYS
 
 
+class BatchTestRegressionOperation(BatchOperation):
+    """A batch operation for test regressions."""
+
+    def __init__(self):
+        super(BatchTestRegressionOperation, self).__init__()
+        self.valid_keys = models.TEST_REGRESSION_VALID_KEYS
+
+
 class BatchDistinctOperation(BatchOperation):
     """A batch operation to retrieve distinct values for a resource."""
 

--- a/app/utils/batch/common.py
+++ b/app/utils/batch/common.py
@@ -118,6 +118,8 @@ def create_batch_operation(json_obj, db_options):
                     batch_op = batchop.BatchTestCaseOperation()
                 elif resource == models.TEST_GROUP_COLLECTION:
                     batch_op = batchop.BatchTestGroupOperation()
+                elif resource == models.TEST_REGRESSION_COLLECTION:
+                    batch_op = batchop.BatchTestRegressionOperation()
 
             _complete_batch_op()
 


### PR DESCRIPTION
Add API entry point to retrieve test regressions and also enable batch
operations on them.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>