### PR TITLE
T18935 Decode query values in batch requests

### DIFF
--- a/app/utils/batch/common.py
+++ b/app/utils/batch/common.py
@@ -22,6 +22,7 @@
 """Common functions for batch operations."""
 
 import types
+import urllib
 
 import models
 import utils.batch.batch_op as batchop
@@ -56,13 +57,11 @@ def get_batch_query_args(query):
                 arg = arg.split("=")
                 # Can't have query with just one element, they have to be
                 # key=value.
-                if len(arg) > 1:
-                    try:
-                        args[arg[0]].append(arg[1])
-                        args[arg[0]] = list(set(args[arg[0]]))
-                    except KeyError:
-                        args[arg[0]] = []
-                        args[arg[0]].append(arg[1])
+                if len(arg) == 2:
+                    name, value = arg
+                    value = urllib.unquote(value)
+                    values = args.setdefault(name, list())
+                    values.append(value)
 
     return args
 


### PR DESCRIPTION
When processing queries in batch requests, decode the values as if
they had been passed in a URL.  This is to allow special characters
such as '&' and '=' to be used in the query values without breaking
the parsing.  They need to be encoded as per RFC 3986.

Also simplify the logic for constructing a dictionary of lists.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>