### PR TITLE
Add test related LAVA log fragment to the test case document

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -141,6 +141,7 @@ LAB_NAME_KEY = "lab_name"
 LIMIT_KEY = "limit"
 LOAD_ADDR_KEY = "load_addr"
 LOG_KEY = 'log'
+LOG_LINES_KEY = "log_lines"
 LT_KEY = "lt"
 MACH_ALIAS_KEY = "mach_alias"
 MACH_KEY = "mach"

--- a/app/models/test_case.py
+++ b/app/models/test_case.py
@@ -54,6 +54,7 @@ class TestCaseDocument(mbase.BaseDocument):
         self._created_on = None
         self._id = None
         self._index = None
+        self._log_lines = []
         self._measurements = []
         self._status = None
         self._test_group_id = None
@@ -122,6 +123,41 @@ class TestCaseDocument(mbase.BaseDocument):
         if self._index:
             raise AttributeError("index already set")
         self._index = value
+
+    @property
+    def log_lines(self):
+        """The log lines stored for the test case."""
+        return self._log_lines
+
+    @log_lines.setter
+    def log_lines(self, value):
+        """Set the log lines associated with the test case.
+
+        :param value: The list of log lines to store.
+        :type value: list
+        """
+        if not value:
+            value = []
+        if not isinstance(value, types.ListType):
+            raise ValueError("Log lines must be passed as a list")
+        self._log_lines = value
+
+    def add_log_lines(self, log_line):
+        """Add a single log line to the test case.
+
+        A log_line should be a non-empty dictionary-like data structure.
+        Empty values will not be stored in this data structure. Typically it'll
+        have a 'dt' and 'msg' keys which are respectively the timestamp
+        and the message.
+
+        :param log_line: A log_line to store
+        :type log_line: dict
+        """
+        if all([log_line, isinstance(log_line, types.DictionaryType)]):
+            self._log_lines.append(log_line)
+        else:
+            raise ValueError(
+                "Log line must be non-empty dictionary-like object")
 
     @property
     def measurements(self):
@@ -204,6 +240,7 @@ class TestCaseDocument(mbase.BaseDocument):
             models.JOB_KEY: self.job,
             models.KERNEL_KEY: self.kernel,
             models.LAB_NAME_KEY: self.lab_name,
+            models.LOG_LINES_KEY: self.log_lines,
             models.MACH_KEY: self.mach,
             models.MEASUREMENTS_KEY: self.measurements,
             models.NAME_KEY: self.name,

--- a/app/models/tests/test_test_case_model.py
+++ b/app/models/tests/test_test_case_model.py
@@ -21,6 +21,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import unittest
+from datetime import datetime
 
 import models.base as mbase
 import models.test_case as mtcase
@@ -48,6 +49,10 @@ class TestTestCaseModel(unittest.TestCase):
         test_case.job = "this-job"
         test_case.kernel = "v123.45"
         test_case.lab_name = "secret"
+        test_case.log_lines = [{
+            'dt': datetime(1970, 1, 1, 0, 0, 0),
+            'msg': 'foo'}]
+        test_case.device_type = "supercar"
         test_case.mach = "batmobile"
         test_case.measurements = [{"foo": 1}]
         test_case.plan = "cunning"
@@ -70,6 +75,9 @@ class TestTestCaseModel(unittest.TestCase):
             "job": "this-job",
             "kernel": "v123.45",
             "lab_name": "secret",
+            "log_lines": [{
+               'dt': datetime(1970, 1, 1, 0, 0, 0),
+               'msg': 'foo'}],
             "mach": "batmobile",
             "measurements": [{"foo": 1}],
             "name": "name",
@@ -98,6 +106,9 @@ class TestTestCaseModel(unittest.TestCase):
         test_case.job = "this-job"
         test_case.kernel = "v123.45"
         test_case.lab_name = "area51"
+        test_case.log_lines = [{
+            'dt': datetime(1970, 1, 1, 0, 0, 0),
+            'msg': 'foo'}]
         test_case.mach = "raspberry"
         test_case.measurements = [{"foo": 1}]
         test_case.plan = "cunning"
@@ -119,6 +130,10 @@ class TestTestCaseModel(unittest.TestCase):
             "job": "this-job",
             "kernel": "v123.45",
             "lab_name": "area51",
+            "log_lines": [{
+                'dt': datetime(1970, 1, 1, 0, 0, 0),
+                'msg': 'foo'}],
+            "device_type": "pi",
             "mach": "raspberry",
             "measurements": [{"foo": 1}],
             "name": "name",
@@ -159,6 +174,9 @@ class TestTestCaseModel(unittest.TestCase):
             "job": "this-job",
             "kernel": "v123.45",
             "lab_name": "spaghetti",
+            "log_lines": [{
+                'dt': datetime(1970, 1, 1, 0, 0, 0),
+                'msg': 'foo'}],
             "mach": "laptop",
             "measurements": [{"foo": 1}],
             "name": "name",

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -27,9 +27,11 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 import codecs
+import dateutil.parser as dparser
 import errno
 import models
 import os
+import re
 import yaml
 import json
 import urllib2
@@ -136,6 +138,10 @@ BL_META_MAP = {
     "kernel_addr": "loadaddr",
     "dtb_addr": "dtb_addr",
 }
+
+LOGIN_CASE_END_PATTERN = re.compile(r'end:.*auto-login-action.*')
+TEST_CASE_SIGNAL_PATTERN = re.compile(
+    r'\<LAVA_SIGNAL_TESTCASE TEST_CASE_ID.+>')
 
 
 def _get_job_meta(meta, job_data):
@@ -321,6 +327,59 @@ def _add_test_log(meta, job_log, suite):
             utils.lava_log_parser.run(log, meta, txt, html)
 
 
+def add_log_fragments(groups, log, end_lines_map, start_log_line):
+    lines_map = _prepare_lines_map(end_lines_map, start_log_line)
+    for path, tc in _test_case_iter(groups):
+        try:
+            lines_range = lines_map[path]
+            tc[models.LOG_LINES_KEY] = _get_log_lines(log, *lines_range)
+        except KeyError:
+            utils.LOG.warn(
+                'No log lines specified for path: {} test_case {}'.format(
+                    path, tc.get('name')))
+
+
+def _test_case_iter(groups):
+    for group in groups:
+        stack = [group]
+        path = [group.get('name')]
+        while stack:
+            node = stack.pop()
+            if node is not group:
+                path.append(node.get('name'))
+            for test_case in node.get('test_cases', []):
+                path.append(test_case.get('name'))
+                yield tuple(path), test_case
+                path.pop()
+            if node is not group:
+                path.pop()
+            for sub_group in node.get('sub_groups', []):
+                stack.append(sub_group)
+
+
+def _prepare_lines_map(end_lines_map, start_log_line):
+    lines_map = OrderedDict(sorted(end_lines_map.items(),
+                                   key=lambda i: i[1]))
+    start_line = start_log_line
+    for path, end_line in lines_map.items():
+        lines_map[path] = (start_line, end_line)
+        start_line = end_line + 1
+    return lines_map
+
+
+def _get_log_lines(log, start_line, end_line):
+    lines = [
+        {
+            'dt': dparser.parse(l['dt']),
+            'msg': l['msg']
+        }
+        for l in log[start_line:end_line]
+        if (l['lvl'] == 'target' and
+            not TEST_CASE_SIGNAL_PATTERN.match(l['msg']))
+    ]
+    return lines
+
+
 def _store_lava_json(job_data, meta, base_path=utils.BASE_PATH):
     """ Save the json LAVA v2 callback object
 
@@ -447,7 +506,14 @@ def _add_login_case(meta, results, cases, name):
     cases.append(test_case)
 
 
-def _add_test_results(group, results):
+def _get_log_line_number(log, pattern):
+    for line_number, line in enumerate(log):
+        msg = line.get('msg', '')
+        if pattern.match(unicode(msg)) is not None:
+            return line_number
+
+
+def _add_test_results(group, results, log_line_data):
     """Add test results from test suite data to a group.
 
     Import test results from a LAVA test suite into a group dictionary with the
@@ -458,6 +524,8 @@ def _add_test_results(group, results):
     :type group: dict
     :param results: Test results from the callback.
     :type results: dict
+    :param log_line_data: dict of {test_case_path: log_end_line}
+    :type log_line_data: dict
     """
     tests = yaml.load(results, Loader=yaml.CLoader)
     test_cases = []
@@ -468,6 +536,7 @@ def _add_test_results(group, results):
             models.VERSION_KEY: "1.1",
             models.TIME_KEY: "0.0",
         }
+        path = [group.get('name')]
         test_case.update({k: test[v] for k, v in TEST_CASE_MAP.iteritems()})
         test_case.update({k: group[k] for k in TEST_CASE_GROUP_KEYS})
         measurement = test.get("measurement")
@@ -482,9 +551,12 @@ def _add_test_results(group, results):
             test_case[models.ATTACHMENTS_KEY] = [reference]
         test_set_name = test_meta.get("set")
         if test_set_name:
+            path.append(test_set_name)
             test_case_list = test_sets.setdefault(test_set_name, [])
         else:
             test_case_list = test_cases
+        path.append(test_case[models.NAME_KEY])
+        log_line_data[tuple(path)] = int(test["log_end_line"])
         test_case[models.INDEX_KEY] = len(test_case_list) + 1
         test_case_list.append(test_case)
 
@@ -615,16 +687,24 @@ def add_tests(job_data, job_meta, lab_name, db_options,
         _store_lava_json(job_data, meta)
         groups = []
         cases = []
-
+        start_log_line = 0
+        log = yaml.load(job_data["log"], Loader=yaml.CLoader)
+        end_lines_map = {}
         for suite_name, results in job_data["results"].iteritems():
             if suite_name == "lava":
                 _add_login_case(meta, results, cases, 'auto-login-action')
+                login_line_num = _get_log_line_number(log,
+                                                      LOGIN_CASE_END_PATTERN)
+                start_log_line = 0 if login_line_num is None \
+                    else login_line_num
             else:
                 suite_name = suite_name.partition("_")[2]
                 group = dict(meta)
                 group[models.NAME_KEY] = suite_name
-                _add_test_results(group, results)
+                _add_test_results(group, results,
+                                  end_lines_map)
                 groups.append(group)
+        add_log_fragments(groups, log, end_lines_map, start_log_line)
 
         if (len(groups) == 1) and (groups[0][models.NAME_KEY] == plan_name):
             # Only one group with same name as test plan

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -250,6 +250,7 @@ def _update_test_case_doc_from_json(case_doc, test_case, errors):
     case_doc.job = test_case.get(models.JOB_KEY)
     case_doc.kernel = test_case.get(models.KERNEL_KEY)
     case_doc.lab_name = test_case.get(models.LAB_NAME_KEY)
+    case_doc.log_lines = test_case.get(models.LOG_LINES_KEY, [])
     case_doc.mach = test_case.get(models.MACH_KEY)
     case_doc.measurements = test_case.get(models.MEASUREMENTS_KEY, [])
     case_doc.status = test_case[models.STATUS_KEY].upper()


### PR DESCRIPTION
LAVA logs from callback are parsed during the test case addition and
test case matching log lines are stored within the test case document as
a list of lines. Each line contains a timestamp and a message. Log lines
are matched on the log line numbers provided in the LAVA callback.

Signed-off-by: Michal Galka <michal.galka@collabora.com>