### PR TITLE
Bump Mongomock to 3.19.0

### DIFF
--- a/app/handlers/tests/test_job_handler.py
+++ b/app/handlers/tests/test_job_handler.py
@@ -81,7 +81,6 @@ class TestJobHandler(TestHandlerBase):
             response.headers["Content-Type"], self.content_type)
         self.assertDictEqual(json.loads(response.body), expected_body)
 
-    @unittest.skip("Mongomock bug in count handling for skip > count")
     @mock.patch("utils.db.find")
     @mock.patch("utils.db.count")
     def test_get_with_limit_and_skip(self, mock_count, mock_find):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 lupa
 mock>0.7.2
-mongomock==3.18.0
+mongomock==3.19.0
 fakeredis


### PR DESCRIPTION
This version contains fix for documenents_count(), so we can re-enable
the test that was skipped.

Signed-off-by: Michal Galka <michal.galka@collabora.com>