### PR TITLE
Add line numbers to the HTML log file

### DIFF
--- a/app/utils/lava_log_parser.py
+++ b/app/utils/lava_log_parser.py
@@ -48,6 +48,7 @@ HTML_HEAD = """\
   a:link {{text-decoration: none }}
   a:visited {{text-decoration: none }}
   a:active {{text-decoration: none }}
+  :target {{ background-color: #000080; }}
   a:hover {{text-decoration: bold; color: red; }}
   ul.results {{
     list-style-type: none;
@@ -122,27 +123,34 @@ def run(log, boot, txt, html):
 
     start_ts = None
     log_buffer = []
+    lineno = 0
 
     for line in log:
+        lineno = lineno + 1
         dt, level, msg = (line.get(k) for k in ["dt", "lvl", "msg"])
         raw_ts = DT_RE.match(dt).groups()[1]
         timestamp = "<span class=\"timestamp\">{}  </span>".format(raw_ts)
+        sl = "<span id=L%d>" % lineno
+        el = "</span>\n"
 
         if isinstance(msg, list):
             msg = ' '.join(msg)
 
         fmt = formats.get(level)
         if fmt:
-            log_buffer.append(timestamp + fmt.format(cgi.escape(msg)))
+            log_buffer .append(
+                ''.join([sl, timestamp, fmt.format(cgi.escape(msg)), el]))
             numbers[level] += 1
         elif level == "target":
             kernel_level = re.match(r'^\<([0-7])\>', msg)
             if kernel_level:
                 fmt = kernel_log_levels[kernel_level.group(1)]
-                log_buffer.append(timestamp + fmt.format(cgi.escape(msg)))
+                log_buffer.append(''.join(
+                        [sl, timestamp, fmt.format(cgi.escape(msg)), el]))
                 kernel_numbers[kernel_level.group(1)] += 1
             else:
-                log_buffer.append(timestamp + cgi.escape(msg) + "\n")
+                log_buffer.append(
+                    ''.join([sl, timestamp, cgi.escape(msg), el]))
             txt.write(msg)
             txt.write("\n")
         elif level == "info" and msg.startswith("Start time: "):

--- a/app/utils/lava_log_parser.py
+++ b/app/utils/lava_log_parser.py
@@ -78,25 +78,25 @@ def run(log, boot, txt, html):
         boot_result_html = "<span class=\"warn\">{}</span>".format(boot_result)
 
     formats = {
-        "emerg": u"<span class=\"alert\">{}</span>\n",
-        "alert": u"<span class=\"alert\">{}</span>\n",
-        "crit": u"<span class=\"alert\">{}</span>\n",
-        "error": u"<span class=\"err\">{}</span>\n",
-        "warning": u"<span class=\"warn\">{}</span>\n",
-        "notice": u"<span class=\"info\">{}</span>\n",
-        "info": u"<span class=\"lavainfo\">{}</span>\n",
-        "debug": u"<span class=\"lavainfo\">{}</span>\n"
+        "emerg": u"<span class=\"alert\">{}</span>",
+        "alert": u"<span class=\"alert\">{}</span>",
+        "crit": u"<span class=\"alert\">{}</span>",
+        "error": u"<span class=\"err\">{}</span>",
+        "warning": u"<span class=\"warn\">{}</span>",
+        "notice": u"<span class=\"info\">{}</span>",
+        "info": u"<span class=\"lavainfo\">{}</span>",
+        "debug": u"<span class=\"lavainfo\">{}</span>"
     }
 
     kernel_log_levels = {
-        "0": u"<span class=\"alert\">{}</span>\n",
-        "1": u"<span class=\"alert\">{}</span>\n",
-        "2": u"<span class=\"alert\">{}</span>\n",
-        "3": u"<span class=\"err\">{}</span>\n",
-        "4": u"<span class=\"warn\">{}</span>\n",
-        "5": u"<span class=\"info\">{}</span>\n",
-        "6": u"<span class=\"info\">{}</span>\n",
-        "7": u"<span class=\"debug\">{}</span>\n",
+        "0": u"<span class=\"alert\">{}</span>",
+        "1": u"<span class=\"alert\">{}</span>",
+        "2": u"<span class=\"alert\">{}</span>",
+        "3": u"<span class=\"err\">{}</span>",
+        "4": u"<span class=\"warn\">{}</span>",
+        "5": u"<span class=\"info\">{}</span>",
+        "6": u"<span class=\"info\">{}</span>",
+        "7": u"<span class=\"debug\">{}</span>",
     }
 
     numbers = {


### PR DESCRIPTION
To be able to point to a specific line in the html log file, we need to
add the line numbers which could be referenced later in the URL.

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>