### PR TITLE
Add the test runner url to the email report

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -180,6 +180,7 @@ TEST_JOB_ID_KEY = "test_job_id"
 TEST_JOB_PATH_KEY = "test_job_path"
 TEST_JOB_URL_KEY = "test_job_url"
 TEST_GROUP_ID_KEY = "test_group_id"
+TEST_RUNNER_URL_KEY = "test_runner_url"
 TEXT_OFFSET_KEY = "text_offset"
 TIME_KEY = "time"
 TIME_RANGE_KEY = "time_range"
@@ -866,6 +867,7 @@ TEST_GROUP_VALID_KEYS = {
             NAME_KEY,
             SUB_GROUPS_KEY,
             TEST_CASES_KEY,
+            TEST_RUNNER_URL_KEY,
             TIME_KEY,
             VERSION_KEY
         ]
@@ -886,6 +888,7 @@ TEST_GROUP_VALID_KEYS = {
         JOB_KEY,
         KERNEL_KEY,
         NAME_KEY,
+        TEST_RUNNER_URL_KEY,
         VERSION_KEY
     ],
     "GET": [
@@ -909,6 +912,7 @@ TEST_GROUP_VALID_KEYS = {
         MACH_KEY,
         NAME_KEY,
         PARENT_ID_KEY,
+        TEST_RUNNER_URL_KEY,
         TIME_KEY,
         VERSION_KEY
     ]
@@ -1159,6 +1163,7 @@ LAVA_CALLBACK_VALID_METADATA_KEYS = {
             "git.url",
             "image.type",
             "image.url",
+            "test_runner.url",
             "job.dtb_url",
             "job.file_server_resource",
             "job.initrd_url",

--- a/app/models/test_group.py
+++ b/app/models/test_group.py
@@ -73,6 +73,7 @@ class TestGroupDocument(modb.BaseDocument):
         self.git_branch = None
         self.git_commit = None
         self.git_describe = None
+        self.test_runner_url = None
         self.git_url = None
         self.image_type = None
         self.index = None
@@ -181,6 +182,7 @@ class TestGroupDocument(modb.BaseDocument):
             models.INDEX_KEY: self.index,
             models.INITRD_KEY: self.initrd,
             models.INITRD_INFO_KEY: self.initrd_info,
+            models.TEST_RUNNER_URL_KEY: self.test_runner_url,
             models.JOB_ID_KEY: self.job_id,
             models.JOB_KEY: self.job,
             models.KERNEL_KEY: self.kernel,

--- a/app/models/tests/test_test_group_model.py
+++ b/app/models/tests/test_test_group_model.py
@@ -72,6 +72,7 @@ class TestTestGroupModel(unittest.TestCase):
         test_group.plan_variant = "tother"
         test_group.sub_groups = [True, False]
         test_group.test_cases = ["foo"]
+        test_group.test_runner_url = "link"
         test_group.time = 10
         test_group.version = "1.1"
         test_group.warnings = 123
@@ -116,6 +117,7 @@ class TestTestGroupModel(unittest.TestCase):
             "name": "name",
             "sub_groups": [True, False],
             "test_cases": ["foo"],
+            "test_runner_url": "link",
             "time": 10,
             "version": "1.1",
             "warnings": 123,
@@ -176,6 +178,7 @@ class TestTestGroupModel(unittest.TestCase):
             "parent_id": "parent-id",
             "plan_variant": "tother",
             "sub_groups": [True, False],
+            "test_runner_url": "link",
             "test_cases": ["foo"],
             "time": 10,
             "version": "1.0",

--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -96,6 +96,7 @@ META_DATA_MAP_TEST = {
     models.GIT_DESCRIBE_KEY: "git.describe",
     models.GIT_URL_KEY: "git.url",
     models.INITRD_KEY: "job.initrd_url",
+    models.TEST_RUNNER_URL_KEY: "test_runner.url",
     models.JOB_KEY: "kernel.tree",
     models.KERNEL_KEY: "kernel.version",
     models.KERNEL_IMAGE_KEY: "job.kernel_image",

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -380,6 +380,7 @@ def _update_test_group_doc_from_json(group_doc, group_dict, errors):
     group_doc.image_type = group_dict.get(models.IMAGE_TYPE_KEY)
     group_doc.initrd = group_dict.get(models.INITRD_KEY)
     group_doc.initrd_info = group_dict.get(models.INITRD_INFO_KEY)
+    group_doc.test_runner_url = group_dict.get(models.TEST_RUNNER_URL_KEY)
     group_doc.job = group_dict.get(models.JOB_KEY)
     group_doc.kernel = group_dict.get(models.KERNEL_KEY)
     group_doc.kernel_image = group_dict.get(models.KERNEL_IMAGE_KEY)

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -45,6 +45,9 @@ Test Failures
     {%- if group.initrd %}
   Rootfs:      {{ group.initrd }}
     {%- endif %}
+    {%- if group.test_runner_url %}
+  Test runner URL: {{ group.test_runner_url }}
+    {%- endif %}
     {%- if not test_suites and group.initrd_info.tests_suites %} {# suites_info #}
 
   Test suite revisions:

--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -52,6 +52,7 @@ TEST_REPORT_FIELDS = [
     models.ID_KEY,
     models.INITRD_KEY,
     models.INITRD_INFO_KEY,
+    models.TEST_RUNNER_URL_KEY,
     models.JOB_ID_KEY,
     models.JOB_KEY,
     models.KERNEL_KEY,


### PR DESCRIPTION
To be able to add the test runner url (ex: Jenkins url) to the email
report, we had to add it first to the test group data base and then
use the field in the email report

Signed-off-by: Khouloud Touil <ktouil@baylibre.com>