### PR TITLE
Add test_group.modules and .modules_dir fields

### DIFF
--- a/app/models/test_group.py
+++ b/app/models/test_group.py
@@ -83,6 +83,8 @@ class TestGroupDocument(modb.BaseDocument):
         self.kernel = None
         self.kernel_image = None
         self.mach = None
+        self.modules = None
+        self.modules_dir = None
         self.plan_variant = None
         self.test_cases = []
         self.parent_id = None
@@ -187,6 +189,8 @@ class TestGroupDocument(modb.BaseDocument):
             models.KERNEL_IMAGE_KEY: self.kernel_image,
             models.LAB_NAME_KEY: self.lab_name,
             models.MACH_KEY: self.mach,
+            models.MODULES_KEY: self.modules,
+            models.MODULES_DIR_KEY: self.modules_dir,
             models.NAME_KEY: self.name,
             models.PLAN_VARIANT_KEY: self.plan_variant,
             models.TEST_CASES_KEY: self.test_cases,

--- a/app/models/tests/test_test_group_model.py
+++ b/app/models/tests/test_test_group_model.py
@@ -68,6 +68,8 @@ class TestTestGroupModel(unittest.TestCase):
         test_group.kernel = "kernel"
         test_group.kernel_image = "kernel-image"
         test_group.mach = "mach"
+        test_group.modules = "moduli"
+        test_group.modules_dir = "moduli-dir"
         test_group.parent_id = "parent-id"
         test_group.plan_variant = "tother"
         test_group.sub_groups = [True, False]
@@ -111,6 +113,8 @@ class TestTestGroupModel(unittest.TestCase):
             "kernel_image": "kernel-image",
             "lab_name": "lab-name",
             "mach": "mach",
+            "modules": "moduli",
+            "modules_dir": "moduli-dir",
             "parent_id": "parent-id",
             "plan_variant": "tother",
             "name": "name",
@@ -172,6 +176,8 @@ class TestTestGroupModel(unittest.TestCase):
             "kernel_image": None,
             "lab_name": "lab-name",
             "mach": "mach",
+            "modules": "modules",
+            "modules_dir": "modules_dir",
             "name": "name",
             "parent_id": "parent-id",
             "plan_variant": "tother",

--- a/app/utils/kci_test/__init__.py
+++ b/app/utils/kci_test/__init__.py
@@ -441,7 +441,6 @@ def _update_test_group_doc_ids(group_doc, database):
         # In case we do not have the job_id key with the previous search.
         if not group_doc.job_id:
             group_doc.job_id = doc_get(models.JOB_ID_KEY)
-        # Get also git information if we do not have them already,
         if not group_doc.compiler:
             group_doc.compiler = doc_get(models.COMPILER_KEY)
         if not group_doc.compiler_version:
@@ -452,6 +451,11 @@ def _update_test_group_doc_ids(group_doc, database):
                 doc_get(models.COMPILER_VERSION_FULL_KEY)
         if not group_doc.cross_compile:
             group_doc.cross_compile = doc_get(models.CROSS_COMPILE_KEY)
+        if not group_doc.modules:
+            group_doc.modules = doc_get(models.MODULES_KEY)
+        if not group_doc.modules_dir:
+            group_doc.modules_dir = doc_get(models.MODULES_DIR_KEY)
+        # Get also git information if we do not have them already,
         if not group_doc.git_branch:
             group_doc.git_branch = doc_get(models.GIT_BRANCH_KEY)
         if not group_doc.git_commit:


### PR DESCRIPTION
Add .modules and .modules_dir fields to TestGroupDocument and populate their values from the associated build document to be able to tell which modules were used in tests.  Update unit tests accordingly.