### PR TITLE
Add Mongo DB index in test cases with job/branch/date/status for trends

### DIFF
--- a/app/handlers/dbindexes.py
+++ b/app/handlers/dbindexes.py
@@ -232,6 +232,12 @@ INDEX_SPECS = {
             (models.LAB_NAME_KEY, pymongo.ASCENDING),
             (models.PLAN_KEY, pymongo.ASCENDING),
         ],
+        [
+            (models.JOB_KEY, pymongo.ASCENDING),
+            (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
+            (models.CREATED_KEY, pymongo.DESCENDING),
+            (models.STATUS_KEY, pymongo.ASCENDING),
+        ],
     ],
 
     models.TEST_GROUP_COLLECTION: [


### PR DESCRIPTION
Add an index for the job/branch/date/status values in test case
entries which is used typically for creating graphs with pass/fail
trends over results sorted by date.  Without this index, the following
error could be seen:

    OperationFailure: Sort operation used more than the maximum
    33554432 bytes of RAM. Add an index, or specify a smaller limit.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>