### PR TITLE
Update kcidb-submit options for kcidb v5

### DIFF
--- a/app/taskqueue/tasks/kcidb.py
+++ b/app/taskqueue/tasks/kcidb.py
@@ -25,16 +25,17 @@ import utils.kcidb
 @taskc.app.task(name="kcidb-build")
 def push_build(args):
     build_id, job_id, first = args
-    bq_options = taskc.app.conf.get("BigQuery_options")
-    if bq_options:
-        utils.kcidb.push_build(build_id, first, bq_options,
+    kcidb_options = taskc.app.conf.get("kcidb_options")
+    if kcidb_options:
+        utils.kcidb.push_build(build_id, first, kcidb_options,
                                taskc.app.conf.db_options)
     return build_id, job_id
 
 
 @taskc.app.task(name="kcidb-tests")
 def push_tests(group_id):
-    bq_options = taskc.app.conf.get("BigQuery_options")
-    if bq_options:
-        utils.kcidb.push_tests(group_id, bq_options, taskc.app.conf.db_options)
+    kcidb_options = taskc.app.conf.get("kcidb_options")
+    if kcidb_options:
+        utils.kcidb.push_tests(group_id, kcidb_options,
+                               taskc.app.conf.db_options)
     return group_id


### PR DESCRIPTION
With the kcidb v5 release, the kcidb-submit command line options have
changed.  Instead of having a BigQuery dataset name, there is now a
project "-p" and a topic "-t".  These are kcidb concepts rather than
BigQuery, so rename the celery config options to kcidb_options and use
project/topic instead of dataset.  The credentials is still an actual
BigQuery credentials so that doesn't change.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>