### PR TITLE
Add log lines to the test report for the failed test cases

### DIFF
--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -66,6 +66,15 @@ Test Regressions
       {{measurement.value}} {{measurement.unit}}
       {%- endfor -%}
     {%- endif %}
+    {%- if tc.log_lines_short %}
+
+    {% for log_line in tc.log_lines_short -%}
+      {{ log_line.dt }}  {{ log_line.msg }}
+    {% endfor -%} {# log_lines_short #}
+    {%- if tc.log_lines_removed -%}
+      ... ({{ tc.log_lines_removed }} line(s) more)
+    {% endif -%} {# log_lines_removed #}
+    {%- endif %} {# log_lines_short #}
   {%- endfor %}
 {%- endfor %} {# test_groups #}
 {%-endif %} {# total fail #}

--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -114,6 +114,11 @@ def _add_test_group_data(group, db, spec, hierarchy=[], regressions=None):
             if regr:
                 regr_count += 1
                 test_case["regression"] = regr
+                test_case["log_lines_short"] = test_case[
+                                                   models.LOG_LINES_KEY][:10]
+                log_lines_count = (len(test_case[models.LOG_LINES_KEY]) - len(
+                    test_case["log_lines_short"]))
+                test_case["log_lines_removed"] = log_lines_count
                 regressions.append(test_case)
         test_cases.append(test_case)
 


### PR DESCRIPTION
Modify test report template to display the log lines stored along with the test cases when the test failed. The number of the log lines in a single fragment is limited to 10. If there are more log lines in
a fragment they are truncated and an appropriate message is added.
