### PR TITLE
T21027 Add serial batch request handler

### DIFF
--- a/app/handlers/batch.py
+++ b/app/handlers/batch.py
@@ -96,6 +96,6 @@ class BatchHandler(hbase.BaseHandler):
         :param db_options: The mongodb database connection parameters.
         :type db_options: dict
         """
-        return taskq.run_batch_group(
+        return taskq.execute_batch_serial(
             json_obj.get(models.BATCH_KEY), db_options
         )

--- a/app/handlers/batch.py
+++ b/app/handlers/batch.py
@@ -96,6 +96,7 @@ class BatchHandler(hbase.BaseHandler):
         :param db_options: The mongodb database connection parameters.
         :type db_options: dict
         """
-        return taskq.execute_batch_serial(
-            json_obj.get(models.BATCH_KEY), db_options
+        task = taskq.execute_batch_serial.apply_async(
+            [json_obj[models.BATCH_KEY], db_options], loglevel=8,
         )
+        return task.get()

--- a/app/taskqueue/tasks/common.py
+++ b/app/taskqueue/tasks/common.py
@@ -38,6 +38,22 @@ def execute_batch(json_obj, db_options):
     return utils.batch.common.execute_batch_operation(json_obj, db_options)
 
 
+@taskc.app.task(name="batch-serial-executor", ignore_result=False)
+def execute_batch_serial(batch_op_list, db_options):
+    """Run list of batch operations in series.
+
+    :param json_obj: List of JSON object with the operations to perform.
+    :type json_obj: list
+    :param db_options: The database connection parameters.
+    :type db_options: dict
+    :return A list with the results of each batch operation.
+    """
+    return [
+        utils.batch.common.execute_batch_operation(batch_op, db_options)
+        for batch_op in batch_op_list
+    ]
+
+
 def run_batch_group(batch_op_list, db_options):
     """Execute a list of batch operations.
 


### PR DESCRIPTION
Rather than setting up a group of Celery tasks to process the batch
requests in parallel, also provide a single Celery task to process
them in series.  This turns out to be a lot faster when the processing
that needs to be done is relatively small due to the big overhead of
setting up a parallel group and putting the results together.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>

- [ ] timing compared on staging with parallel handler
- [ ] unit tests updated