### PR TITLE
Fix pycodestyle error in callback/lava.py

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -373,9 +373,9 @@ def _get_log_lines(log, start_line, end_line):
             'dt': dparser.parse(l['dt']),
             'msg': l['msg']
         }
-        for l in log[start_line:end_line]
-        if (l['lvl'] == 'target' and
-            not TEST_CASE_SIGNAL_PATTERN.match(l['msg']))
+        for line in log[start_line:end_line]
+        if (line['lvl'] == 'target' and
+            not TEST_CASE_SIGNAL_PATTERN.match(line['msg']))
     ]
     return lines
 


### PR DESCRIPTION
Fix a pycodestyle error due to a variable name being too short in
app/utils/callback/lava.py.

Fixes: 3e77a4e0953e ("Add test related LAVA log fragment to the test case document")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>