### PR TITLE
T21218 Add matching baseline URL and deprecation warning to boot reports

### DIFF
--- a/app/utils/report/boot.py
+++ b/app/utils/report/boot.py
@@ -77,6 +77,10 @@ FIRST_FAIL_TXT = u"first fail: {bad_kernel:s}"
 FIRST_FAIL_HTML = \
     u"first fail: <a href=\"{boot_id_url:s}\">{bad_kernel:s}</a>"
 
+BASELINE_SUMMARY_URL = u"\
+{base_url:s}/test/job/{job:s}/branch/{git_branch:s}/\
+kernel/{kernel:s}/plan/baseline/"
+
 
 def create_regressions_data(boot_docs, boot_data):
     """Create the regressions data for the email report.
@@ -902,6 +906,7 @@ def _create_boot_email(boot_data):
             tested_string = tested_string.format(**boot_data)
 
     boot_summary_url = rcommon.BOOT_SUMMARY_URL.format(**boot_data)
+    baseline_summary_url = BASELINE_SUMMARY_URL.format(**boot_data)
     build_summary_url = rcommon.BUILD_SUMMARY_URL.format(**boot_data)
 
     boot_data["tree_string"] = G_(u"Tree: {job:s}").format(**boot_data)
@@ -927,6 +932,7 @@ def _create_boot_email(boot_data):
     boot_data["git_url_string"] = (git_txt_string, git_html_string)
 
     boot_data["platforms"] = _parse_and_structure_results(boot_data)
+    boot_data["baseline_summary_url"] = baseline_summary_url
 
     if models.EMAIL_TXT_FORMAT_KEY in email_format:
         boot_data["full_boot_summary"] = (

--- a/app/utils/report/templates/boot.html
+++ b/app/utils/report/templates/boot.html
@@ -5,8 +5,30 @@
         <title>{{ subject_str }}</title>
     </head>
     <body>
-        <span><strong>{{ subject_str }}</strong></span>
-        <br />
+        <div style="align: center; text-align: justified; border: 2px solid red;; padding: 12px;">
+          <h2 align="center">&#x26A0;&nbsp;Boot tests are now deprecated&nbsp;&#x26A0;</h2>
+          <p>
+            As kernelci.org is expanding its functional testing capabilities,
+            the concept of boot testing is now deprecated.  Boot results are
+            scheduled to be dropped on <span style="font-weight: bold">5th June
+            2020</span>.  The full schedule for boot tests deprecation is
+            available
+            on <a href="https://github.com/kernelci/kernelci-backend/issues/238">GitHub issue #238</a>.
+          </p>
+          <p>
+            The new equivalent is the
+            <span style="font-weight: bold">baseline</span>
+            test suite which also runs sanity checks using dmesg and
+            <a href="https://github.com/kernelci/bootrr">bootrr</a>.
+          </p>
+          <p>
+            See the <span style="font-weight: bold">baseline results for this
+            kernel revision</span> on this page:<br />
+            <a href="{{ baseline_summary_url }}">{{ baseline_summary_url }}</a>
+          </p>
+        </div>
+
+        <p><span><strong>{{ subject_str }}</strong></span></p>
         <table style="border: none; padding-top: 15px; padding-bottom: 15px;">
             <tbody>
                 <tr><td>{{ full_boot_summary }}</td></tr>

--- a/app/utils/report/templates/boot.txt
+++ b/app/utils/report/templates/boot.txt
@@ -1,3 +1,20 @@
+******************************************
+* WARNING: Boot tests are now deprecated *
+******************************************
+
+As kernelci.org is expanding its functional testing capabilities, the concept
+of boot testing is now deprecated.  Boot results are scheduled to be dropped on
+*5th June 2020*.  The full schedule for boot tests deprecation is available on
+this GitHub issue: https://github.com/kernelci/kernelci-backend/issues/238
+
+The new equivalent is the *baseline* test suite which also runs sanity checks
+using dmesg and bootrr: https://github.com/kernelci/bootrr
+
+See the *baseline results for this kernel revision* on this page:
+{{ baseline_summary_url }}
+
+-------------------------------------------------------------------------------
+
 {{ subject_str }}
 {# leave an empty space #}
 {{ full_boot_summary }}


### PR DESCRIPTION
Now that boot reports are being deprecated, add a paragraph to explain
the transition to baseline and a link to the matching baseline test
results on the frontend in boot email reports.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>