### PR TITLE
T21218 Only show regressions in test email reports

### DIFF
--- a/app/taskqueue/tasks/report.py
+++ b/app/taskqueue/tasks/report.py
@@ -207,6 +207,9 @@ def send_test_report(job, git_branch, kernel, plan, report_data, email_opts):
 
     body, subject, headers = test_report
 
+    if body is None:
+        return 200
+
     status, errors = utils.emails.send_email(
         subject, body, None, email_opts, taskc.app.conf.mail_options, headers)
 

--- a/app/utils/report/templates/test.txt
+++ b/app/utils/report/templates/test.txt
@@ -1,13 +1,14 @@
 {{ subject_str }}
 
-Test results summary
---------------------
+Regressions Summary
+-------------------
 
 {{ summary_headers }}
 {%- for group in test_groups %}
 {{ group.summary }}
 {%- endfor %}
 
+  Details:  {{ base_url }}/test/job/{{ tree }}/branch/{{ branch }}/kernel/{{ kernel }}/plan/{{ plan }}/
 {% block plan_description %}
   Test:     {{ plan }}{% endblock %}
   Tree:     {{ tree }}
@@ -29,63 +30,42 @@ Test results summary
 {%- if totals.FAIL != 0 %} {# total fail #}
 
 
-Test Failures
--------------
-{% for group in test_groups %} {# test_groups #}
-  {%- if group.total_results.FAIL %} {# group fail #}
+Test Regressions
+----------------
+{%- for group in test_groups %} {# test_groups #}
+
 
 {{ summary_headers }}
 {{ group.summary }}
+
+  Details:     {{ base_url }}/test/plan/id/{{ group._id }}
 
   Results:     {{ group.total_results.PASS }} PASS, {{ group.total_results.FAIL }} FAIL, {{ group.total_results.SKIP }} SKIP
   Full config: {{ group.defconfig_full }}
   Compiler:    {{ group.build_environment }}{% if group.compiler_version_full %} ({{ group.compiler_version_full }}){% endif %}
   Plain log:   {{ storage_url }}/{{ group.file_server_resource }}/{{ group.lab_name }}/{{ group.boot_log }}
   HTML log:    {{ storage_url }}/{{ group.file_server_resource }}/{{ group.lab_name }}/{{ group.boot_log_html }}
-    {%- if group.initrd %}
+  {%- if group.initrd %}
   Rootfs:      {{ group.initrd }}
-    {%- endif %}
-    {%- if not test_suites and group.initrd_info.tests_suites %} {# suites_info #}
+  {%- endif %}
+  {%- if not test_suites and group.initrd_info.tests_suites %} {# suites_info #}
 
   Test suite revisions:
-      {%- for suite in group.initrd_info.tests_suites|sort(attribute='name') %}
+    {%- for suite in group.initrd_info.tests_suites|sort(attribute='name') %}
     {{ suite.name }}
       URL:  {{ suite.git_url }}
       SHA:  {{ suite.git_commit }}
-      {%- endfor %}
-    {%- endif %} {# suites_info #}
-    {%- if group.results.FAIL %} {# group fail #}
+    {%- endfor %}
+  {%- endif %} {# suites_info #}
 
-  {{ group.test_cases|length }} tests: {{ group.results.PASS }} PASS, {{ group.results.FAIL }} FAIL, {{ group.results.SKIP }} SKIP
-      {%- for tc in group.test_cases %}
-        {%- if 'FAIL' == tc.status %}
-    * {{ tc.name }}:
-        {{ tc.failure_message }}
-          {%- if tc.measurements %}
-            {%- for measurement in tc.measurements %}
-        {{measurement.value}} {{measurement.unit}}
-            {%- endfor -%}
-          {% endif %}
-        {%- endif %}
-      {%- endfor %}
-    {%- endif %}  {# group fail #}
-    {%- for sg in group.sub_groups|sort(attribute='index') %} {# sub_groups #}
-      {%- if sg.results.FAIL %} {# sg fail #}
-
-  {{ sg.name }} - {{ sg.test_cases|length }} tests: {{ sg.results.PASS }}  PASS, {{ sg.results.FAIL }} FAIL, {{ sg.results.SKIP }} SKIP
-        {%- for tc in sg.test_cases %}
-          {%- if 'FAIL' == tc.status %}
-    * {{ tc.name }}:
-        {{ tc.failure_message }}
-            {%- if tc.measurements %}
-              {%- for measurement in tc.measurements %}
-        {{measurement.value}} {{measurement.unit}}
-              {%- endfor -%}
-            {% endif %}
-          {%- endif %}
-        {%- endfor %}
-      {%- endif %} {# sg fail #}
-    {%- endfor %} {# sub_groups #}
-  {% endif %}  {# group fail #}
+  {% for tc in group.regressions -%}
+  * {{ tc.test_case_path }}: {{ base_url }}/test/case/id/{{ tc._id }}
+      {{ tc.failure_message }}
+    {%- if tc.measurements %}
+      {%- for measurement in tc.measurements %}
+      {{measurement.value}} {{measurement.unit}}
+      {%- endfor -%}
+    {%- endif %}
+  {%- endfor %}
 {%- endfor %} {# test_groups #}
 {%-endif %} {# total fail #}


### PR DESCRIPTION
Now that we can have links to detailed views on the frontend for test
results and regressions, only show regressions in the test email
report:

* add "regressions" list to top-level group data with test cases that
  have caused a regression, including all sub-groups

* only send a report when there were some regressions, otherwise
  return an email body of None and HTTP 200

* remove all conditionals about number of test case failures in the
  template and iterate over the group["regressions"]

* remove iteration over sub-groups in the email template by showing
  the full test case path for each regression

* add links to the detailed results for the overall test plan report,
  for each test plan run and each individual test case regression

* adjust formatting and headings in the email template accordingly

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>