### PR TITLE
Clean LAVA test logs

### DIFF
--- a/app/utils/callback/__init__.py
+++ b/app/utils/callback/__init__.py
@@ -18,3 +18,4 @@
 """Functions to process callbacks."""
 
 import lava
+import lava_filters

--- a/app/utils/callback/lava_filters.py
+++ b/app/utils/callback/lava_filters.py
@@ -1,0 +1,42 @@
+"""
+This module is meant to contain the lava log filtering functions.
+These functions are used to filter out the content of the LAVA log when LAVA
+callback is being processed.
+
+Filtering functions should follow some rules:
+
+- Name of the filtering function must start with `filter_`
+- It can take only one argument which is a log line text to process
+- It should return boolean value:
+    - True - log line stays in the log
+    - False - log line will be deleted
+
+`LAVA_FILTERS` is a list of filtering functions (function objects)
+and it gets automatically populated during module import.
+"""
+
+import re
+import inspect
+
+
+LAVA_SIGNAL_PATTERN = re.compile(
+    r'\<LAVA_SIGNAL_.+>')
+
+
+def filter_log_levels(log_line):
+    return log_line['lvl'] == 'target'
+
+
+def filter_lava_signal(log_line):
+    return not LAVA_SIGNAL_PATTERN.match(log_line['msg'])
+
+
+def _get_lava_filters():
+    filters = []
+    for name, obj in globals().items():
+        if name.startswith('filter') and inspect.isfunction(obj):
+            filters.append(obj)
+    return filters
+
+
+LAVA_FILTERS = _get_lava_filters()


### PR DESCRIPTION
Changes in this commit add code for running filtering functions on data
received from LAVA callback. It adds logic to run the filters and adjust
the log fragments accordingly as well as a convenient way to add new
filters if/when needed. Current log filtering has been moved to the new
structures.

Signed-off-by: Michal Galka <michal.galka@collabora.com>