### PR TITLE
kcidb: use only the SHA1 for revision_id

### DIFF
--- a/app/utils/kcidb.py
+++ b/app/utils/kcidb.py
@@ -107,7 +107,7 @@ def push_build(build_id, first, kcidb_options, db_options={}, db=None):
     ns = kcidb_options.get("namespace", "kernelci.org")
     build = utils.db.find_one2(db[models.BUILD_COLLECTION], build_id)
     build_id = _make_id(build[models.ID_KEY], ns)
-    revision_id = _make_id(build[models.GIT_COMMIT_KEY], ns)
+    revision_id = build[models.GIT_COMMIT_KEY]
 
     kcidb_data = {
         'version': '1',


### PR DESCRIPTION
For compatability with kcidb v3 schema, remove the extra namespace
from the revision ID and only use the commit SHA1.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>