### PR TITLE
Fix job status in LAVA callback handling

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -131,6 +131,7 @@ def _get_job_meta(meta, job_data):
     :param job_data: The map of keys to search for in the JSON and update.
     :type job_data: dict
     """
+    meta[models.BOOT_RESULT_KEY] = LAVA_JOB_RESULT[job_data["status"]]
     meta[models.BOARD_INSTANCE_KEY] = job_data["actual_device_id"]
 
 


### PR DESCRIPTION
Fix the job status field in LAVA callback handling.  This was dropped
by mistake when removing support for boot results.  The job status is
used in particular when generating the HTML job log.

Fixes: feb2aa89277b ("Remove boot callback support from LAVA")
Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>