### PR TITLE
Change LAVA log filtering regexp to be more inclusive

### DIFF
--- a/app/utils/callback/lava.py
+++ b/app/utils/callback/lava.py
@@ -396,9 +396,8 @@ def _store_lava_json(job_data, meta, base_path=utils.BASE_PATH):
         f.write(json.dumps(job_data))
 
 
-def _add_login_case(meta, results, cases, name):
+def _add_login_case(meta, tests, cases, name):
     # ToDo: consolidate with _add_test_results
-    tests = results
     tests_by_name = {t['name']: t for t in tests}
     login = tests_by_name.get(name)
     if not login:

--- a/app/utils/callback/lava_filters.py
+++ b/app/utils/callback/lava_filters.py
@@ -37,7 +37,7 @@ import inspect
 
 
 LAVA_SIGNAL_PATTERN = re.compile(
-    r'\<LAVA_SIGNAL_.+>')
+    r'^<LAVA_.+>')
 
 
 def filter_log_levels(log_line):


### PR DESCRIPTION
Previous expression captured only <LAVA_SIGNAL* messages what made some of the unwanted LAVA log messages to slip under the radar. Changing regexp to filter out everything that starts with <LAVA_* works better for our purposes.
