### PR TITLE
T23358 Enable range keys in batch count queries

### DIFF
--- a/app/handlers/count.py
+++ b/app/handlers/count.py
@@ -96,6 +96,8 @@ def count_one_collection(
     spec = handlers.common.query.get_query_spec(
         query_args_func, valid_keys)
     handlers.common.query.get_and_add_date_range(spec, query_args_func)
+    handlers.common.query.get_and_add_gte_lt_keys(
+        spec, query_args_func, valid_keys)
     utils.update_id_fields(spec)
 
     if spec:


### PR DESCRIPTION
Enable keys to count using range keys such as "gte" (greater or equal
than) or "lt" (less than) when doing batch count queries.  This is
useful in particular to count the documents with a number of errors or
warnings greather than 0 (gte 1).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>