### PR TITLE
T23919 - Show number of regressions in the e-mail reports

### DIFF
--- a/app/utils/report/test.py
+++ b/app/utils/report/test.py
@@ -162,7 +162,7 @@ def _create_summaries(groups):
         return item
 
     columns = [
-        "platform", "arch", "lab", "compiler", "defconfig", "results"
+        "platform", "arch", "lab", "compiler", "defconfig", "regressions"
     ]
     rows = [
         (
@@ -171,8 +171,8 @@ def _create_summaries(groups):
             g['lab_name'],
             g['build_environment'],
             g['defconfig_full'],
-            "{}/{}".format(g['total_results']['PASS'], g['total_tests']),
-        ) for i, g in enumerate(groups)
+            str(g['total_regr']),
+        ) for g in groups
     ]
     squashed = [tuple(squash(item, 28) for item in row)for row in rows]
 


### PR DESCRIPTION
Fixes for a GH Issue #257
https://github.com/kernelci/kernelci-backend/issues/257
It replaces "results" column which values seemed unintuitive with
"regressions" column that simply displays the total number of
regressions.