### PR TITLE
Drop background option when creating indexes

### DIFF
--- a/app/handlers/dbindexes.py
+++ b/app/handlers/dbindexes.py
@@ -346,4 +346,4 @@ def ensure_indexes(database):
             expire = INDEX_EXPIRATION.get((collection, name))
             if name not in db_indexes:
                 kw = {'expireAfterSeconds': expire} if expire else {}
-                db_collection.create_index(index, background=True, **kw)
+                db_collection.create_index(index, **kw)


### PR DESCRIPTION
The "background" option was used prior to Mongo DB v4.2 to avoid
locking all the database while creating the indexes.  Starting with
v4.2, only the collection where the index is being created is locked.
The "background" option is no longer used in practice, and the
resulting indexes provide better performance.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>