### PR TITLE
Drop the "Not tracking" noisy log messages

### DIFF
--- a/app/utils/kci_test/regressions.py
+++ b/app/utils/kci_test/regressions.py
@@ -104,7 +104,6 @@ def _check_and_track(test_case, group, last_case, last_group, db, spec,
     regr[models.KERNEL_KEY] = last_group[models.KERNEL_KEY]
     regr_doc = utils.db.find_one2(db[models.TEST_REGRESSION_COLLECTION], regr)
     if not regr_doc:
-        utils.LOG.info("Not tracking: {}".format(test_case_path))
         return (200, None)
 
     utils.LOG.info("Tracking regression: {}".format(test_case_path))


### PR DESCRIPTION
The "Not tracking" messages are not too helpful and can be very noisy
with test errors that never get fixed.  Drop them to clen up the
Celery logs.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>