### PR TITLE
Allow UNKNOWN test status as it's reported by LAVA

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -332,7 +332,8 @@ VALID_TEST_CASE_STATUS = [
     ERROR_STATUS,
     FAIL_STATUS,
     PASS_STATUS,
-    SKIP_STATUS
+    SKIP_STATUS,
+    UNKNOWN_STATUS
 ]
 
 # The valid collections for the bisect handler.


### PR DESCRIPTION
Under some particular circumstances, LAVA test cases can have the
"UNKNOWN" status.  This also happens to be defined as a status string
in the backend models, so enable it.  Otherwise, an exception is
raised and the results are lost.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>