### PR TITLE
Add test_case index for SoC view per tree (job)

### DIFF
--- a/app/handlers/dbindexes.py
+++ b/app/handlers/dbindexes.py
@@ -173,6 +173,12 @@ INDEX_SPECS = {
             (models.STATUS_KEY, pymongo.ASCENDING),
         ],
         [
+            (models.CREATED_KEY, pymongo.DESCENDING),
+            (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
+            (models.KERNEL_KEY, pymongo.ASCENDING),
+            (models.MACH_KEY, pymongo.ASCENDING),
+        ],
+        [
             (models.GIT_BRANCH_KEY, pymongo.ASCENDING),
             (models.JOB_KEY, pymongo.ASCENDING),
             (models.KERNEL_KEY, pymongo.DESCENDING),


### PR DESCRIPTION
Add Mongo DB index for the test_case collection to speed up queries of
this kind:

  https://api.kernelci.org/test/case?sort=created_on&date_range=14&sort_order=-1&field=job&field=git_branch&field=created_on&field=mach&field=kernel&aggregate=job&mach=qcom

This is used by the frontend on SoC views to show results for a git
tree (called "job" in the database).

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>