### PR TITLE
Add persistent kcidb connection per celery worker

### DIFF
--- a/app/taskqueue/celery.py
+++ b/app/taskqueue/celery.py
@@ -23,11 +23,13 @@
 from __future__ import absolute_import
 
 import ast
-import celery
 import celery.schedules
+import celery.signals
 import io
 import kombu.serialization
 import os
+import utils
+from utils.kcidb import KcidbSubmit
 
 import taskqueue.celeryconfig as celeryconfig
 import taskqueue.serializer as serializer
@@ -78,6 +80,31 @@ if os.path.exists(CELERY_CONFIG_FILE):
     app.conf.update(updates)
 
 app.conf.update(CELERYBEAT_SCHEDULE=CELERYBEAT_SCHEDULE)
+
+app.kcidb_pool = {}
+
+
+@celery.signals.worker_process_init.connect
+def worker_init_handler(*args, **kwargs):
+    pid = os.getpid()
+    kcidb_options = app.conf.get("kcidb_options")
+    if kcidb_options.get("debug"):
+        utils.LOG.info("Creating KcidbSubmit object for PID: {}".format(pid))
+    app.kcidb_pool[pid] = KcidbSubmit(kcidb_options)
+
+
+@celery.signals.worker_process_shutdown.connect
+def worker_process_init_handler(*args, **kwargs):
+    pid = os.getpid()
+    kcidb_submit = app.kcidb_pool.get(pid)
+    kcidb_options = app.conf.get("kcidb_options")
+    if kcidb_submit:
+        if kcidb_options.get("debug"):
+            utils.LOG.info('Terminating kcidb-submit for worker pid: {}'
+                           .format(pid))
+        kcidb_submit.terminate()
+    elif kcidb_options.get("debug"):
+        utils.LOG.info('No kcidb-submit for worker pid: {}'.format(pid))
 
 
 if __name__ == "__main__":

--- a/app/taskqueue/tasks/kcidb.py
+++ b/app/taskqueue/tasks/kcidb.py
@@ -17,6 +17,7 @@
 
 """All kcidb related tasks."""
 
+import os
 import taskqueue.celery as taskc
 import utils
 import utils.kcidb
@@ -26,10 +27,12 @@ import utils.kcidb
 def push_build(args):
     build_id, job_id, first = args
     kcidb_options = taskc.app.conf.get("kcidb_options")
-
+    pid = os.getpid()
+    kcidb_submit = taskc.app.kcidb_pool.get(pid)
     if kcidb_options:
         try:
             utils.kcidb.push_build(build_id, first, kcidb_options,
+                                   kcidb_submit,
                                    taskc.app.conf.db_options)
         except Exception, e:
             utils.LOG.exception(e)
@@ -40,10 +43,12 @@ def push_build(args):
 @taskc.app.task(name="kcidb-tests")
 def push_tests(group_id):
     kcidb_options = taskc.app.conf.get("kcidb_options")
-
+    pid = os.getpid()
+    kcidb_submit = taskc.app.kcidb_pool[pid]
     if kcidb_options:
         try:
             utils.kcidb.push_tests(group_id, kcidb_options,
+                                   kcidb_submit,
                                    taskc.app.conf.db_options)
         except Exception, e:
             utils.LOG.exception(e)


### PR DESCRIPTION
During celery worker startup there are KcidbSubmit objects created for each worker.
When a celery task that needs to push data to KCIDB is run a kcidb-submit process is spawned by the KcidbSubmit object.
These processes live until owning celery worker is terminated.
Tasks that communicate with kcidb stream data to the appropriate kcidb-submit process stdin through a pipe.
