### PR TITLE
Disable pushing data to KCIDB when configuration is missing

### DIFF
--- a/app/taskqueue/celery.py
+++ b/app/taskqueue/celery.py
@@ -86,25 +86,28 @@ app.kcidb_pool = {}
 
 @celery.signals.worker_process_init.connect
 def worker_init_handler(*args, **kwargs):
-    pid = os.getpid()
     kcidb_options = app.conf.get("kcidb_options")
-    if kcidb_options.get("debug"):
-        utils.LOG.info("Creating KcidbSubmit object for PID: {}".format(pid))
-    app.kcidb_pool[pid] = KcidbSubmit(kcidb_options)
+    if kcidb_options:
+        pid = os.getpid()
+        if kcidb_options.get("debug"):
+            utils.LOG.info("Creating KcidbSubmit object for PID: {}"
+                           .format(pid))
+        app.kcidb_pool[pid] = KcidbSubmit(kcidb_options)
 
 
 @celery.signals.worker_process_shutdown.connect
 def worker_process_init_handler(*args, **kwargs):
-    pid = os.getpid()
-    kcidb_submit = app.kcidb_pool.get(pid)
     kcidb_options = app.conf.get("kcidb_options")
-    if kcidb_submit:
-        if kcidb_options.get("debug"):
-            utils.LOG.info('Terminating kcidb-submit for worker pid: {}'
-                           .format(pid))
-        kcidb_submit.terminate()
-    elif kcidb_options.get("debug"):
-        utils.LOG.info('No kcidb-submit for worker pid: {}'.format(pid))
+    if kcidb_options:
+        pid = os.getpid()
+        kcidb_submit = app.kcidb_pool.get(pid)
+        if kcidb_submit:
+            if kcidb_options.get("debug"):
+                utils.LOG.info('Terminating kcidb-submit for worker pid: {}'
+                               .format(pid))
+            kcidb_submit.terminate()
+        elif kcidb_options.get("debug"):
+            utils.LOG.info('No kcidb-submit for worker pid: {}'.format(pid))
 
 
 if __name__ == "__main__":

--- a/app/taskqueue/tasks/kcidb.py
+++ b/app/taskqueue/tasks/kcidb.py
@@ -27,9 +27,9 @@ import utils.kcidb
 def push_build(args):
     build_id, job_id, first = args
     kcidb_options = taskc.app.conf.get("kcidb_options")
-    pid = os.getpid()
-    kcidb_submit = taskc.app.kcidb_pool.get(pid)
     if kcidb_options:
+        pid = os.getpid()
+        kcidb_submit = taskc.app.kcidb_pool.get(pid)
         try:
             utils.kcidb.push_build(build_id, first, kcidb_options,
                                    kcidb_submit,
@@ -43,9 +43,9 @@ def push_build(args):
 @taskc.app.task(name="kcidb-tests")
 def push_tests(group_id):
     kcidb_options = taskc.app.conf.get("kcidb_options")
-    pid = os.getpid()
-    kcidb_submit = taskc.app.kcidb_pool[pid]
     if kcidb_options:
+        pid = os.getpid()
+        kcidb_submit = taskc.app.kcidb_pool[pid]
         try:
             utils.kcidb.push_tests(group_id, kcidb_options,
                                    kcidb_submit,


### PR DESCRIPTION
Check if KCIDB configuration (kcidb_options) is present. Don't push data to KCIDB when config is missing.
