### PR TITLE
T27888 config rework

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -26,9 +26,6 @@
 # along with this library; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-# The default mongodb database name.
-DB_NAME = "kernel-ci"
-
 DEFAULT_SCHEMA_VERSION = "1.0"
 
 # i18n domain name.

--- a/app/server.py
+++ b/app/server.py
@@ -24,12 +24,12 @@
 
 import concurrent.futures
 import os
+import sys
 import tornado
 import tornado.httpserver
 import tornado.netutil
 import tornado.options as topt
 import tornado.web
-import uuid
 
 import handlers.app as happ
 import handlers.dbindexes as hdbindexes
@@ -188,6 +188,10 @@ if __name__ == "__main__":
         "xheaders": True,
         "max_buffer_size": topt.options.buffer_size
     }
+
+    if not topt.options.master_key:
+        utils.LOG.error('master_key not specified')
+        sys.exit(1)
 
     if topt.options.unixsocket:
         application = KernelCiBackend()

--- a/app/server.py
+++ b/app/server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
-# Copyright (C) Collabora Limited 2017
+# Copyright (C) Collabora Limited 2017, 2021
 # Author: Guillaume Tucker <guillaume.tucker@collabora.com>
+# Author: Michal Galka <michal.galka@collabora.com>
 #
 # Copyright (C) Linaro Limited 2014,2015,2016,2017
 # Author: Milo Casagrande <milo.casagrande@linaro.org>
@@ -38,6 +39,7 @@ import utils.db
 
 
 DEFAULT_CONFIG_FILE = "/etc/kernelci/kernelci-backend.cfg"
+DEFAULT_MONGODB_DBNAME = "kernel-ci"
 
 topt.define(
     "master_key", default=str(uuid.uuid4()), type=str, help="The master key")
@@ -57,6 +59,10 @@ topt.define(
 topt.define(
     "mongodb_host",
     default="localhost", type=str, help="The DB host to connect to")
+topt.define(
+    "mongodb_dbname", default=DEFAULT_MONGODB_DBNAME, type=str,
+    help="The DB name to use"
+)
 topt.define(
     "mongodb_port", default=27017, type=int, help="The DB port to connect to")
 topt.define(
@@ -121,6 +127,7 @@ class KernelCiBackend(tornado.web.Application):
             "mongodb_pool": topt.options.mongodb_pool,
             "mongodb_port": topt.options.mongodb_port,
             "mongodb_user": topt.options.mongodb_user,
+            "mongodb_dbname": topt.options.mongodb_dbname,
             "redis_db": topt.options.redis_db,
             "redis_host": topt.options.redis_host,
             "redis_password": topt.options.redis_password,

--- a/app/utils/db.py
+++ b/app/utils/db.py
@@ -60,19 +60,18 @@ def get_db_client(db_options):
     return CLIENT
 
 
-def get_db_connection2(db_options, db_name=models.DB_NAME):
+def get_db_connection2(db_options):
     """Get a connection to a mongodb database.
 
     Get and in case authenticate to the mongodb database.
 
     :param db_options: The connection parameters.
     :type db_options: dict
-    :param db_name: The name of the database to connect to.
-    :type db_name: str
     :return A mongodb instance.
     """
     if not db_options or not isinstance(db_options, types.DictType):
         db_options = {}
+    db_name = db_options.get("mongodb_dbname", "")
 
     db = get_db_client(db_options)[db_name]
 
@@ -85,14 +84,11 @@ def get_db_connection2(db_options, db_name=models.DB_NAME):
     return db
 
 
-def get_db_connection(db_options, db_name=models.DB_NAME):
+def get_db_connection(db_options):
     """Retrieve a mongodb database connection.
 
     :params db_options: The mongodb database connection parameters.
     :type db_options: dict
-    :param db_name: The name of the database to connect to.
-    Defaults to "kernel-ci".
-    :type db_name: str
     :return A mongodb database instance.
     """
     if not db_options or not isinstance(db_options, types.DictType):
@@ -106,6 +102,7 @@ def get_db_connection(db_options, db_name=models.DB_NAME):
 
     db_user = db_options_get("mongodb_user", "")
     db_pwd = db_options_get("mongodb_password", "")
+    db_name = db_options_get("mongodb_dbname", "")
 
     connection = pymongo.MongoClient(
         host=db_host, maxPoolSize=db_pool, port=db_port, w="majority",


### PR DESCRIPTION
1) Move mongodb database name to configuration
    
Introduced mongodb_dbname parameter which allows to specify mongodb
database name in application configuraion istead of it being harcoded in
models.__init__.py. This commit also refactors database connection
handling functions accordingly.

2)  Enable config file and unix soccket paths as config options
    
Configuration file path can be now passed as a CLI option. If the
option is not present kernelci-backend will look for the config at
/etc/kernelci/kernelci-backend.cfg
A Unix socket path can be now defined as a "socket" option. It can be
provided as a CLI or config file option. Default value is
/tmp/kernelci-backend.socket

3) Fail if master_key is not defined
    
Prevent application from starting when master_key is not defined either
as a CLI option or in the config file. The server doesn't set a random
uuid when master_key is not provided any more.

4) Add user configuration file path as celery CLI option
  
Added -u/--user-config parameter to celery app which can be used to pass
alternative configuration file path. Default value remains defined as
/etc/kernelci/kernelci-celery.cfg
