### PR TITLE
bisect: add a link to the dashboard in bisect email

### DIFF
--- a/app/utils/report/bisect.py
+++ b/app/utils/report/bisect.py
@@ -151,6 +151,8 @@ def create_bisect_report(data, email_options, db_options,
         "defconfig": doc[models.DEFCONFIG_FULL_KEY],
         "compiler": compiler_str,
         "test_case_path": doc[models.TEST_CASE_PATH_KEY],
+        "test_case_id": test_case[models.ID_KEY],
+        "base_url": rcommon.DEFAULT_BASE_URL,
         "show": log_data["show"],
         "log": log_data["log"],
     }

--- a/app/utils/report/templates/bisect.txt
+++ b/app/utils/report/templates/bisect.txt
@@ -19,6 +19,9 @@ Summary:
   HTML log:   {{ log_url_html }}
   Result:     {{ found }}
 
+See this regression on the Kernel CI dashboard:
+{{ test_case_path }}: {{ base_url }}/test/case/id/{{ test_case_id }}
+
 Checks:
 {%- for check, result in checks|dictsort %}
   {{ "%-11s" | format(check + ":",) }} {{ result }}


### PR DESCRIPTION
The idea of this PR is to provide in the bisect report a link to the dashboard (https://linux.kernelci.org/test/case/id/6397b076556bd83b952abd03/)  aiming to facilitate the work that Shreeya is doing reporting regressions to the kernel community. 

Signed-off-by: Alexandra Pereira <alexandra.pereira@collabora.com>